### PR TITLE
misc(version): Bump to 0.23.0-beta

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.22.1"
+appVersion: "0.23.0"
 description: the Lago open source billing app
 name: lago
 version: 0.2.0

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@ replicas:
   front: 1
   worker: 1
 
-lago_release: "0.22.1-beta"
+lago_release: "0.23.0-beta"
 
 # This "embedded" redis is for quick development purpose. NEVER USE IN PRODUCTION
 redis:


### PR DESCRIPTION
- Bump to Lago `v0.23.0-beta`