### PR TITLE
fix smtp nil error when smtp is enabled

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -128,7 +128,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: smtpPassword
             - name: LAGO_SMTP_PORT
-              value: {{ .Values.smtp.port }}
+              value: "{{ .Values.global.smtp.port }}"
             {{ end }}
             {{ if .Values.global.newRelic.enabled }}
             - name: NEW_RELIC_KEY

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -52,7 +52,7 @@ data:
   {{ end }}
 
   {{ if .Values.global.smtp.enabled }}
-  smtpusername: {{ .Values.global.smtp.username | b64enc }}
+  smtpUsername: {{ .Values.global.smtp.username | b64enc }}
   smtpPassword: {{ .Values.global.smtp.password | b64enc }}
   {{ end }}
 

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -118,7 +118,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: smtpPassword
             - name: LAGO_SMTP_PORT
-              value: {{ .Values.smtp.port }}
+              value: "{{ .Values.global.smtp.port }}"
             {{ end }}
             {{ if .Values.global.newRelic.enabled }}
             - name: NEW_RELIC_KEY


### PR DESCRIPTION
fix smtp nil error when smtp enabled equals true. tested in the K3S locally but you can verify it once more.