### PR TITLE
My fork!

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.51.1-beta"
 description: the Lago open source billing app
 name: lago
-version: 0.3.1
+version: 0.3.1-tag1
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.51.1-beta"
+appVersion: "0.53.3-beta"
 description: the Lago open source billing app
 name: lago
-version: 0.3.1-tag1
+version: 1.0.1-tag1
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.53.3-beta"
 description: the Lago open source billing app
 name: lago
-version: 1.0.1-tag1
+version: 1.0.1-tag2
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
-# Lago Helm Chart
+# Lago Helm Chart - Camille's fork
 
-Version: 1.0.1-tag1
-Lago Version : v0.53.3-beta
-Lago API Version : v0.53.3-beta-hacked
+This repository holds my fork of [Lago](https://getlago.com/)'s [Helm chart](https://github.com/getlago/lago-helm-charts).
 
-## Configuration
-
-You can start with a very small configuration.
-The only fields required are `frontUrl` and `apiUrl`, since no ingress is managed with this version right now, you have to define the URL your application will be deployed to.
+For more details, visit the corresponding Pull Request!

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Lago Helm Chart
 
-Version: 0.3.0
-Lago Version : v0.51.1-beta
+Version: 1.0.1-tag1
+Lago Version : v0.53.3-beta
+Lago API Version : v0.53.3-beta-hacked
 
 ## Configuration
 
 You can start with a very small configuration.
 The only fields required are `frontUrl` and `apiUrl`, since no ingress is managed with this version right now, you have to define the URL your application will be deployed to.
-
-
-

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -137,7 +137,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.api.image.repository | default "getlago/api"}}:{{ .Values.api.image.tag | default (printf "v%s" .Values.version) }}
           name: {{ .Release.Name }}-api
           ports:
             - containerPort: 3000

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         io.lago.service: {{ .Release.Name }}-api
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - ./scripts/start.sh

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -47,7 +47,7 @@ data:
   {{ end }}
 
   {{ if .Values.global.s3.enabled }}
-  awsS3AccessKeyId: {{ .Values.global.s3.aws.accessKeyid | b64enc }}
+  awsS3AccessKeyId: {{ .Values.global.s3.aws.accessKeyId | b64enc }}
   awsS3SecretAccessKey: {{ .Values.global.s3.aws.secretAccessKey | b64enc }}
   {{ end }}
 

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -9,20 +9,20 @@ data:
   {{ $secretObj := (lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-secrets") | default dict }}
   {{ $secretData := (get $secretObj "data" | default dict) }}
 
-  {{ $rsaPrivateKey := (get $secretData "rsaPrivateKey") | default (genPrivateKey "rsa" | b64enc | b64enc) }}
-  rsaPrivateKey: {{ $rsaPrivateKey | quote }}
+  {{ $rsaPrivateKey := (get $secretData "rsaPrivateKey") | default (genPrivateKey "rsa" | b64enc) }}
+  rsaPrivateKey: {{ .Values.secrets.rsaPrivateKey | default $rsaPrivateKey | b64enc | quote }}
 
-  {{ $secretKeyBase := (get $secretData "secretKeyBase") | default (randAlphaNum 64 | b64enc | b64enc) }}
-  secretKeyBase: {{ $secretKeyBase | quote }}
+  {{ $secretKeyBase := (get $secretData "secretKeyBase") | default (randAlphaNum 64 | b64enc) }}
+  secretKeyBase: {{ .Values.secrets.secretKeyBase | default $secretKeyBase | b64enc | quote }}
 
-  {{ $encryptionPrimaryKey := (get $secretData "encryptionPrimaryKey") | default (randAlphaNum 32 | b64enc | b64enc) }}
-  encryptionPrimaryKey: {{ $encryptionPrimaryKey | quote }}
+  {{ $encryptionPrimaryKey := (get $secretData "encryptionPrimaryKey") | default (randAlphaNum 32 | b64enc) }}
+  encryptionPrimaryKey: {{ .Values.secrets.encryptionPrimaryKey | default $encryptionPrimaryKey | b64enc | quote }}
 
-  {{ $encryptionDeterministicKey := (get $secretData "encryptionDeterministicKey") | default (randAlphaNum 32 | b64enc | b64enc) }}
-  encryptionDeterministicKey: {{ $encryptionDeterministicKey | quote }}
+  {{ $encryptionDeterministicKey := (get $secretData "encryptionDeterministicKey") | default (randAlphaNum 32 | b64enc ) }}
+  encryptionDeterministicKey: {{ .Values.secrets.encryptionDeterministicKey | default $encryptionDeterministicKey | b64enc | quote }}
 
-  {{ $encryptionKeyDerivationSalt := (get $secretData "encryptionKeyDerivationSalt") | default (randAlphaNum 32 | b64enc | b64enc) }}
-  encryptionKeyDerivationSalt: {{ $encryptionKeyDerivationSalt | quote }}
+  {{ $encryptionKeyDerivationSalt := (get $secretData "encryptionKeyDerivationSalt") | default (randAlphaNum 32 | b64enc) }}
+  encryptionKeyDerivationSalt: {{ .Values.secrets.encryptionKeyDerivationSalt | default $encryptionKeyDerivationSalt | b64enc | quote }}
 
   {{ if .Values.postgresql.enabled }}
   {{ $pgDatabase := .Values.global.postgresql.auth.database }}

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,9 @@ version: "0.52.0-beta"
 #apiUrl:
 #frontUrl:
 
+imagePullSecrets: {}
+  #- name: ghcr-pull-secret
+
 # Only for Development, Staging or PoC, you should use a managed Redis instance for Production
 redis:
   enabled: true
@@ -57,11 +60,11 @@ global:
   newRelic:
     enabled: false
     #key
-  
+
   # You can disable Lago's signup
   signup:
     enabled: true
-  
+
   #ingress:
     #frontHostname:
     #apiHostname:

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,13 @@ version: "0.52.0-beta"
 #apiUrl:
 #frontUrl:
 
+secrets: {}
+  #rsaPrivateKey:
+  #secretKeyBase:
+  #encryptionPrimaryKey:
+  #encryptionDeterministicKey:
+  #encryptionKeyDerivationSalt:
+
 imagePullSecrets: {}
   #- name: ghcr-pull-secret
 

--- a/values.yaml
+++ b/values.yaml
@@ -72,7 +72,8 @@ global:
   signup:
     enabled: true
 
-  #ingress:
+  ingress:
+    enabled: false
     #frontHostname:
     #apiHostname:
     #className:

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-version: "0.52.0-beta"
+version: "0.53.3-beta"
 
 #apiUrl:
 #frontUrl:
@@ -89,7 +89,7 @@ front:
 api:
   image: {}
     #repository: ghcr.io/your-org/lago-api
-    #tag: v0.52.0-beta-fork1
+    #tag: v0.53.3-beta-fork1
   replicas: 1
   service:
     port: 3000

--- a/values.yaml
+++ b/values.yaml
@@ -76,6 +76,9 @@ front:
     cpu: "100m"
 
 api:
+  image: {}
+    #repository: ghcr.io/your-org/lago-api
+    #tag: v0.52.0-beta-fork1
   replicas: 1
   service:
     port: 3000

--- a/values.yaml
+++ b/values.yaml
@@ -101,7 +101,7 @@ api:
   sidekiqWeb:
     enabled: true
   resources:
-    memory: 128
+    memory: 1024
     cpu: "100m"
   volumes:
     storage: "10Gi"
@@ -113,7 +113,7 @@ worker:
     env: "production"
     logStdout: true
   resources:
-    memory: 128
+    memory: 512
     cpu: "100m"
 
 eventsWorker:
@@ -123,7 +123,7 @@ eventsWorker:
     env: "production"
     logStdout: true
   resources:
-    memory: 128
+    memory: 256
     cpu: "100m"
 
 clock:
@@ -132,7 +132,7 @@ clock:
     env: "production"
     logStdout: true
   resources:
-    memory: 128
+    memory: 256
     cpu: "100m"
 
 pdf:


### PR DESCRIPTION
## What is this?

I found tons of stuff I needed to edit on the chart to make it work for me (migrating from an older version of the chart).
So, I decided to build a fork. It was a good idea... I always come back and make changes to it.

I am going to keep updating it as I need, and of course, I will closely follow Lago releases.

If maintainers want, I will gladly make individual pull requests for the different features that my fork has.

(non-exhaustive) feature list:

- ability to specify secrets (useful to migrate without loosing data — **I highly recommend backing up the auto-generated keys that are stored in a secret**)
- using the latest version of the app
- more lenient memory requests (useful on clusters where overloads happen frequently!)
- ability to specify a custom Docker repository and tag for the API deployment (useful if you need to make edits to the API)
- not crashing when ingress is not explicitely enabled

## How to use

I am running it with the following values.yaml:

```yaml
apiUrl: https://billing.mycompany.com
frontUrl: https://billing.mycompany.com

postgresql:
  enabled: false # I am using the same database for my app

global:
  databaseUrl: postgresql://xxxx:xxx@xxxx:1234/lago?sslmode=require
  segment:
    enabled: false # sorry, Lago team...
  signup:
    enabled: false
  ## This is ABSOLUTELY necessary if your cluster does not support multi-attach volumes
  s3:
    enabled: true
    aws:
      accessKeyId: xxxx
      secretAccessKey: xxxx
      bucket: xxxxxx-lago
      region: xxxx-xxxxx-xxx-xxx

# These are not necessary for a new installation since they will be auto-generated,
# but they are necessary when migrating to the newest version of the chart.
secrets:
  rsaPrivateKey: xxxx
  secretKeyBase: xxxx
  encryptionPrimaryKey: xxxx
  encryptionDeterministicKey: xxxx
  encryptionKeyDerivationSalt: xxxx

## This part is all about using my fork of the API
api:
  image:
    repository: ghcr.io/mycompany/lago-api
    tag: v0.53.3-beta-fork1

imagePullSecrets:
  - name: ghcr-credentials
```

I am using Caddy on a simple VPS to act as a frontend for my whole cluster.

My configuration for Lago looks like this:

```Caddyfile
https://billing.mycompany.com {
	reverse_proxy /graphql http://lago-new-api-svc.infra.svc.cluster.local:3000 {
		header_up Host billing.mycompany.com
		header_down -Server
	}

	reverse_proxy /rails/* http://lago-new-api-svc.infra.svc.cluster.local:3000 {
		header_up Host billing.mycompany.com
		header_down -Server
	}

	reverse_proxy http://lago-new-front-svc.infra.svc.cluster.local {
		header_up Host billing.mycompany.com
		header_down -Server
	}
}
```

As you can see, there are some path rewrites to do 👀

It would be nice to have one endpoint that does everything: /rails/, /graphql/ and the frontend.