### PR TITLE
misc(pods): Add annotations and Service accounts on pods

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.54.2-beta"
 description: the Lago open source billing app
 name: lago
-version: 0.3.7
+version: 0.4.0
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lago Helm Chart
 
-Version: 0.3.7
+Version: 0.4.0
 Lago Version : v0.54.2-beta
 
 ## Configuration

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         io.lago.service: {{ .Release.Name }}-api
+      annotations:
+        {{ range $key, $value := .Values.api.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{ end }}
     spec:
       containers:
         - args:
@@ -163,4 +167,7 @@ spec:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-storage-data
+      {{ end }}
+      {{ if .Values.api.serviceAccountName }}
+      serviceAccountName: {{ .Values.api.serviceAccountName | quote }}
       {{ end }}

--- a/templates/clock-deployment.yaml
+++ b/templates/clock-deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         io.lago.service: {{ .Release.Name }}-clock
+      annotations:
+        {{ range $key, $value := .Values.clock.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{ end }}
     spec:
       containers:
         - args:

--- a/templates/events-worker-deployment.yaml
+++ b/templates/events-worker-deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         io.lago.service: {{ .Release.Name }}-events-worker
+      annotations:
+        {{ range $key, $value := .Values.eventsWorker.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{ end }}
     spec:
       containers:
         - args:

--- a/templates/front-deployment.yaml
+++ b/templates/front-deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         io.lago.service: {{ .Release.Name }}-front
+      annotations:
+        {{ range $key, $value := .Values.front.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{ end }}
     spec:
       containers:
         - env:

--- a/templates/pdf-deployment.yaml
+++ b/templates/pdf-deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         io.lago.service: {{ .Release.Name }}-pdf
+      annotations:
+        {{ range $key, $value := .Values.pdf.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{ end }}
     spec:
       containers:
         - image: getlago/lago-gotenberg:7.8.2

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         io.lago.service: {{ .Release.Name }}-worker
+      annotations:
+        {{ range $key, $value := .Values.worker.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{ end }}
     spec:
       containers:
         - args:
@@ -150,4 +154,7 @@ spec:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-storage-data
+      {{ end }}
+      {{ if .Values.worker.serviceAccountName }}
+      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
       {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,7 @@ front:
   resources:
     memory: 512
     cpu: "200m"
+  # podAnnotations:
 
 api:
   replicas: 1
@@ -93,6 +94,8 @@ api:
     cpu: "1000m"
   volumes:
     storage: "10Gi"
+  # serviceAccountName:
+  # podAnnotations:
 
 worker:
   replicas: 1
@@ -104,6 +107,8 @@ worker:
   resources:
     memory: 1024
     cpu: "1000m"
+  # serviceAccountName:
+  # podAnnotations:
 
 eventsWorker:
   replicas: 1
@@ -115,6 +120,7 @@ eventsWorker:
   resources:
     memory: 1024
     cpu: "1000m"
+  # podAnnotations:
 
 clock:
   replicas: 1
@@ -125,6 +131,7 @@ clock:
   resources:
     memory: 256
     cpu: "100m"
+  # podAnnotations:
 
 pdf:
   replicas: 1
@@ -133,3 +140,4 @@ pdf:
   resources:
     memory: 2048
     cpu: "1000m"
+  # podAnnotations


### PR DESCRIPTION
- Support custom annotations on deployments
- Support `serviceAccountName` to permit usage of AWS IRSA, note : you should create your service account before