### PR TITLE
fix(s3): Fix S3 secret env var population. Added S3 endpoint support

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -128,14 +128,18 @@ spec:
             {{ if .Values.global.s3.enabled }}
             - name: LAGO_USE_AWS_S3
               value: "true"
-            {{ if .Values.global.s3.accessKeyId }}
+            {{ if .Values.global.s3.aws.endpoint }}
+            - name: LAGO_AWS_S3_ENDPOINT
+              value: {{ .Values.global.s3.aws.endpoint | quote }}
+            {{ end }}
+            {{ if .Values.global.s3.aws.accessKeyId }}
             - name: LAGO_AWS_S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-secrets
                   key: awsS3AccessKeyId
             {{ end }}
-            {{ if .Values.global.s3.secretAccessKey }}
+            {{ if .Values.global.s3.aws.secretAccessKey }}
             - name: LAGO_AWS_S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -110,14 +110,18 @@ spec:
             {{ if .Values.global.s3.enabled }}
             - name: LAGO_USE_AWS_S3
               value: "true"
-            {{ if .Values.global.s3.accessKeyId }}
-              - name: LAGO_AWS_S3_ACCESS_KEY_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ .Release.Name }}-secrets
-                    key: awsS3AccessKeyI
+            {{ if .Values.global.s3.aws.endpoint }}
+            - name: LAGO_AWS_S3_ENDPOINT
+              value: {{ .Values.global.s3.aws.endpoint | quote }}
             {{ end }}
-            {{ if .Values.global.s3.secretAccessKey }}
+            {{ if .Values.global.s3.aws.accessKeyId }}
+            - name: LAGO_AWS_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: awsS3AccessKeyId
+            {{ end }}
+            {{ if .Values.global.s3.aws.secretAccessKey }}
             - name: LAGO_AWS_S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,7 @@ global:
     #   secretAccessKey:
     #   bucket:
     #   region:
+    #   endpoint:
   smtp:
     enabled: false
     #address:
@@ -57,17 +58,17 @@ global:
   newRelic:
     enabled: false
     #key:
-  
+
   # You can disable Lago's signup
   signup:
     enabled: true
-  
+
   ingress:
     enabled: false
     #frontHostname:
     #apiHostname:
     #className:
-  
+
   #serviceAccountName:
   #kubeCtlVersion:
 


### PR DESCRIPTION
Fixes the use of `global.s3.aws.accessKeyId` and properly assign it to the API & Worker's env vars.
Also added the `endpoint` support for S3 compatible services like MinIO.