### PR TITLE
Redis secret is missing.

### DIFF
--- a/templates/migrate-job.yaml
+++ b/templates/migrate-job.yaml
@@ -40,6 +40,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-secrets
                   key: databaseUrl
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: redisUrl
             - name: LAGO_RSA_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
To fix Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Errno::ECONNREFUSED)