### PR TITLE
Update chart apiVersion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.2.1"
 description: the Lago open source billing app
 name: lago


### PR DESCRIPTION
## Changes

- The `Charts.yaml` file has he v2 syntax (presence of a `dependencies` key, [source](https://helm.sh/docs/topics/charts/#the-apiversion-field)) but is declared as v1. Patch it into **v2**.

## Impact

- This fixes charts installs with helm v3
- This will force the chart to be only available with helm v3