### PR TITLE
Add by default a `ttlSecondsAfterFinished`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,6 @@ appVersion: "1.2.1"
 description: the Lago open source billing app
 name: lago
 version: 1.2.1
-kubeVersion: '>= 1.23.0-0'
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.2.1"
 description: the Lago open source billing app
 name: lago
 version: 1.2.1
-kubeVersion: '>= 1.23.0'
+kubeVersion: '>= 1.23.0-0'
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.2.1"
 description: the Lago open source billing app
 name: lago

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: "1.2.1"
 description: the Lago open source billing app
 name: lago
 version: 1.2.1
+kubeVersion: '>= 1.23.0'
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -20,3 +20,4 @@
 {{- else -}}
 {{ printf "%s-migrate-%s" .Release.Name (.Values | toYaml | cat .Chart.Version | sha256sum | trunc 8) }}
 {{- end }}
+{{- end}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -13,3 +13,10 @@
 {{ printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor }}
 {{- end }}
 {{- end}}
+
+{{- define "migrateJobName" }}
+{{- if .Values.job.mirate.nameOverride -}}
+{{ .Values.job.mirate.nameOverride }}
+{{- else -}}
+{{ printf "%s-migrate-%s" .Release.Name (.Values | toYaml | cat .Chart.Version | sha256sum | susbstr 0 8) }}
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -15,8 +15,8 @@
 {{- end}}
 
 {{- define "migrateJobName" }}
-{{- if .Values.job.mirate.nameOverride -}}
-{{ .Values.job.mirate.nameOverride }}
+{{- if .Values.job.migrate.nameOverride -}}
+{{ .Values.job.migrate.nameOverride }}
 {{- else -}}
 {{ printf "%s-migrate-%s" .Release.Name (.Values | toYaml | cat .Chart.Version | sha256sum | trunc 8) }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -18,5 +18,5 @@
 {{- if .Values.job.mirate.nameOverride -}}
 {{ .Values.job.mirate.nameOverride }}
 {{- else -}}
-{{ printf "%s-migrate-%s" .Release.Name (.Values | toYaml | cat .Chart.Version | sha256sum | susbstr 0 8) }}
+{{ printf "%s-migrate-%s" .Release.Name (.Values | toYaml | cat .Chart.Version | sha256sum | trunc 8) }}
 {{- end }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           image: "docker.io/bitnami/kubectl:{{ include "kubectlVersion" . }}"
           args:
             - wait
-            - job/{{ .Release.Name }}-migrate
+            - job/{{ include "migrateJobName" . }}
             - --for=condition=complete
             - --timeout=180s
       containers:

--- a/templates/events-worker-deployment.yaml
+++ b/templates/events-worker-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           image: "docker.io/bitnami/kubectl:{{ include "kubectlVersion" . }}"
           args:
             - wait
-            - job/{{ .Release.Name }}-migrate
+            - job/{{ include "migrateJobName" . }}
             - --for=condition=complete
             - --timeout=180s
       containers:

--- a/templates/migrate-job.yaml
+++ b/templates/migrate-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
+  ttlSecondsAfterFinished: {{ .Values.job.migrate.ttlSecondsAfterFinished }}
   template:
     metadata:
       name: "{{ .Release.Name }}-migrate"

--- a/templates/migrate-job.yaml
+++ b/templates/migrate-job.yaml
@@ -1,14 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-migrate"
+  name: "{{ include "migrateJobName" . }}"
   labels:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
-  ttlSecondsAfterFinished: {{ .Values.job.migrate.ttlSecondsAfterFinished }}
   template:
     metadata:
-      name: "{{ .Release.Name }}-migrate"
+      name: "{{ include "migrateJobName" . }}"
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/templates/serviceaccount.yml
+++ b/templates/serviceaccount.yml
@@ -26,7 +26,7 @@ rules:
     {{ if .Values.redis.enabled }}
     - {{ .Release.Name }}-redis-master-0
     {{ end}}
-    - {{ .Release.Name }}-migrate
+    - {{ include "migrateJobName" . }}
   verbs:
     - get
     - list

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           image: "docker.io/bitnami/kubectl:{{ include "kubectlVersion" . }}"
           args:
             - wait
-            - job/{{ .Release.Name }}-migrate
+            - job/{{ include "migrateJobName" . }}
             - --for=condition=complete
             - --timeout=180s
       containers:

--- a/values.yaml
+++ b/values.yaml
@@ -179,7 +179,7 @@ pdf:
 
 job:
   migrate:
-    ttlSecondsAfterFinished: 60
+    nameOverride: null
     podAnnotations: {}
     podLabels: {}
     resources: {}

--- a/values.yaml
+++ b/values.yaml
@@ -179,6 +179,7 @@ pdf:
 
 job:
   migrate:
+    ttlSecondsAfterFinished: 60s
     podAnnotations: {}
     podLabels: {}
     resources: {}

--- a/values.yaml
+++ b/values.yaml
@@ -179,7 +179,7 @@ pdf:
 
 job:
   migrate:
-    ttlSecondsAfterFinished: 60s
+    ttlSecondsAfterFinished: 60
     podAnnotations: {}
     podLabels: {}
     resources: {}


### PR DESCRIPTION
# Support TTL for jobs

## What was changed?

- Modified jobs so they have a controlled random string (generated from the hash of the values.yaml concatenated with the Chart Version) within their name

## Why?

- Kubernetes jobs are immutable, so if the job still exists and helm tries to apply a new job on top of it, helm will raise an error saying that the Job resource is immutable. Adding some suffix to its name will allow to create a new job on a new version of the release. 

## Existing problems

- Using `kubectl watch` to verify that migrations have run is probably a bad idea: Users could, for instance, decide to run migrations another mechanism and not the batch API. Plus, that prevents the job from being cleaned up (or else deployments won't run) and will accumulate on the namespace. Instead, checking migration version should probably be done directly in the software, against some value in the database.
- Jobs will accumulate and won't be cleaned up with the current set-up.
