### PR TITLE
Enhance API and Frontend Configuration Documentation and Default PVC Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,24 +70,34 @@ helm install my-lago-release . \
 
 ### Frontend Configuration
 
-| Parameter                          | Description                                        | Default   |
-|-------------------------------------|----------------------------------------------------|-----------|
-| `front.replicas`                    | Number of frontend replicas                        | `1`       |
-| `front.service.port`                | Frontend service port                              | `80`      |
-| `front.resources.requests.memory`   | Memory request for the frontend                    | `512Mi`   |
-| `front.resources.requests.cpu`      | CPU request for the frontend                       | `200m`    |
+| Parameter                           | Description                                         | Default      |
+|--------------------------------------|-----------------------------------------------------|--------------|
+| `front.replicas`                     | Number of frontend replicas                         | `1`          |
+| `front.service.port`                 | Frontend service port                               | `80`         |
+| `front.resources.requests.memory`    | Memory request for the frontend                     | `512Mi`      |
+| `front.resources.requests.cpu`       | CPU request for the frontend                        | `200m`       |
+| `front.podAnnotations`               | Annotations to add to the frontend pod              | `{}`         |
+| `front.podLabels`                    | Labels to add to the frontend pod                   | `{}`         |
+
 
 ### API Configuration
 
-| Parameter                          | Description                                        | Default   |
-|-------------------------------------|----------------------------------------------------|-----------|
-| `api.replicas`                      | Number of API replicas                             | `1`       |
-| `api.service.port`                  | API service port                                   | `3000`    |
-| `api.rails.maxThreads`              | Maximum number of threads for the Rails app        | `10`      |
-| `api.rails.webConcurrency`          | Web concurrency setting for Rails                  | `4`       |
-| `api.rails.env`                     | Rails environment                                  | `production` |
-| `api.resources.requests.memory`     | Memory request for the API                         | `1Gi`     |
-| `api.resources.requests.cpu`        | CPU request for the API                            | `1000m`   |
+| Parameter                           | Description                                         | Default      |
+|--------------------------------------|-----------------------------------------------------|--------------|
+| `api.replicas`                       | Number of API replicas                              | `1`          |
+| `api.service.port`                   | API service port                                    | `3000`       |
+| `api.rails.maxThreads`               | Maximum number of threads for the Rails app         | `10`         |
+| `api.rails.webConcurrency`           | Web concurrency setting for Rails                   | `4`          |
+| `api.rails.env`                      | Rails environment                                   | `production` |
+| `api.rails.logStdout`                | Enable or disable logging to stdout                 | `true`       |
+| `api.rails.logLevel`                 | Log level for the Rails app                         | `error`      |
+| `api.sidekiqWeb.enabled`             | Enable or disable Sidekiq Web                       | `true`       |
+| `api.resources.requests.memory`      | Memory request for the API                          | `1Gi`        |
+| `api.resources.requests.cpu`         | CPU request for the API                             | `1000m`      |
+| `api.volumes.accessModes`            | Access mode for the API's persistent storage        | `ReadWriteOnce` |
+| `api.volumes.storage`                | Storage size for the API's persistent volume claim  | `10Gi`       |
+| `api.podAnnotations`                 | Annotations to add to the API pod                   | `{}`         |
+| `api.podLabels`                      | Labels to add to the API pod                        | `{}`         |
 
 ### Worker Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This Helm chart deploys the Lago billing system with various optional dependencies such as Redis, PostgreSQL, and MinIO. Below are details about configuring the chart for different environments.
 
+[![Lago Release](https://img.shields.io/github/v/release/getlago/lago)](https://github.com/getlago/lago/releases)
+
+[![Helm Chart Release](https://img.shields.io/github/v/release/getlago/lago-helm-charts)](https://github.com/getlago/lago-helm-charts/releases)
+
 ## Prerequisites
 
 - Kubernetes 1.19+
@@ -13,16 +17,18 @@ This Helm chart deploys the Lago billing system with various optional dependenci
 
 To install the chart with the release name `my-lago-release`:
 
+```
 helm install my-lago-release .
-
+```
 You can customize the installation by overriding values in `values.yaml` with your own. The full list of configurable parameters can be found in the following sections.
 
 ### Sample Command
 
+```sh
 helm install my-lago-release . \
   --set apiUrl=mydomain.dev \
   --set frontUrl=mydomain.dev
-
+```
 
 ## Configuration
 
@@ -109,7 +115,13 @@ helm install my-lago-release . \
 | `minio.buckets[].versioning`        | Enable versioning for the bucket                   | `false`   |
 | `minio.buckets[].objectlocking`     | Enable object locking for the bucket               | `false`   |
 
+## Storage Recommendation
 
+We **strongly recommend** using either **Amazon S3** or **MinIO** for object storage when deploying Lago. These solutions provide reliable, scalable storage that can be accessed by multiple pods without encountering issues.
+
+If neither S3 nor MinIO is configured, the system will default to using a Persistent Volume Claim (PVC). However, this approach is **strongly discouraged** as it can lead to issues such as multi-attach errors when volumes are accessed by more than one pod simultaneously. For this reason, it is important to configure S3 or MinIO to avoid potential complications with PVCs.
+
+By opting for S3 or MinIO, you ensure better reliability and scalability for your deployment.
 
 For additional customization, refer to the comments in `values.yaml`.
 

--- a/templates/storage-data-persistentvolumeclaim.yaml
+++ b/templates/storage-data-persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.s3.enabled -}}
+{{- if not .Values.global.s3.enabled and not .Values.minio.enabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/storage-data-persistentvolumeclaim.yaml
+++ b/templates/storage-data-persistentvolumeclaim.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-storage-data
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.api.volumes.accessModes | default "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ .Values.api.volumes.storage }}

--- a/values.yaml
+++ b/values.yaml
@@ -121,6 +121,7 @@ api:
       memory: 1Gi
       cpu: '1000m'
   volumes:
+    accessModes: ReadWriteOnce
     storage: '10Gi'
   podAnnotations: {}
   podLabels: {}


### PR DESCRIPTION
This pull request improves the documentation for both the API and frontend configurations by adding missing parameters and clarifying default behaviors. The following changes have been made:

- **API Configuration**: Added documentation for missing parameters such as `logStdout`, `logLevel`, `sidekiqWeb.enabled`, `volumes.accessModes`, `volumes.storage`, `podAnnotations`, and `podLabels`.
- **Frontend Configuration**: Included documentation for `podAnnotations` and `podLabels` parameters.
- **Persistent Volume Claim (PVC) Handling**: Clarified that the default behavior is to fallback to a PVC if neither S3 nor MinIO is configured, although this is strongly discouraged.

This PR aims to provide clearer guidance on configuration options and their defaults, improving overall usability and deployment reliability.
