### PR TITLE
feat(helm): add support for extraEnv variables in api, front, worker, events-worker, clock, and pdf deployments for dynamic environment configuration

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -130,6 +130,12 @@ spec:
               value: {{ .Values.api.rails.webConcurrency | quote }}
             - name: LAGO_LOG_LEVEL
               value: {{ .Values.api.rails.logLevel | quote }}
+            {{- with .Values.api.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
             {{ if .Values.global.license }}
             - name: LAGO_LICENSE
               valueFrom:
@@ -245,13 +251,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{ if not .Values.global.s3.enabled }}
+          {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{ if not .Values.global.s3.enabled }}
+      {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/templates/clock-deployment.yaml
+++ b/templates/clock-deployment.yaml
@@ -51,6 +51,12 @@ spec:
                   key: redisUrl
             - name: RAILS_LOG_TO_STDOUT
               value: {{ .Values.clock.rails.logStdout | quote }}
+            {{- with .Values.clock.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
             - name: LAGO_RSA_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/templates/events-worker-deployment.yaml
+++ b/templates/events-worker-deployment.yaml
@@ -63,6 +63,12 @@ spec:
                   key: redisUrl
             - name: RAILS_LOG_TO_STDOUT
               value: {{ .Values.eventsWorker.rails.logStdout | quote }}
+            {{- with .Values.eventsWorker.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
             - name: LAGO_RSA_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/templates/front-deployment.yaml
+++ b/templates/front-deployment.yaml
@@ -31,6 +31,12 @@ spec:
               value: {{ .Values.apiUrl | quote }}
             - name: LAGO_DISABLE_SIGNUP
               value: {{ not .Values.global.signup.enabled | quote }}
+            {{- with .Values.front.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           image: getlago/front:v{{ .Values.version }}
           name: {{ .Release.Name }}-front
           ports:

--- a/templates/pdf-deployment.yaml
+++ b/templates/pdf-deployment.yaml
@@ -31,4 +31,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
+          env:
+            {{- with .Values.pdf.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
       restartPolicy: Always

--- a/templates/storage-data-persistentvolumeclaim.yaml
+++ b/templates/storage-data-persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.s3.enabled and not .Values.minio.enabled -}}
+{{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -70,6 +70,12 @@ spec:
               value: {{ required "frontUrl value is required" .Values.frontUrl | quote }}
             - name: RAILS_LOG_TO_STDOUT
               value: {{ .Values.worker.rails.logStdout | quote }}
+            {{- with .Values.worker.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
             - name: LAGO_RSA_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,8 @@ front:
       cpu: '200m'
   podAnnotations: {}
   podLabels: {}
+  extraEnv: {}
+
 
 api:
   replicas: 1
@@ -123,6 +125,7 @@ api:
   volumes:
     accessModes: ReadWriteOnce
     storage: '10Gi'
+  extraEnv: {}
   podAnnotations: {}
   podLabels: {}
 
@@ -139,6 +142,7 @@ worker:
       cpu: '1000m'
   podAnnotations: {}
   podLabels: {}
+  extraEnv: {}
 
 eventsWorker:
   replicas: 1
@@ -153,6 +157,8 @@ eventsWorker:
       cpu: '1000m'
   podAnnotations: {}
   podLabels: {}
+  extraEnv: {}
+
 
 clock:
   replicas: 1
@@ -166,6 +172,8 @@ clock:
       cpu: '100m'
   podAnnotations: {}
   podLabels: {}
+  extraEnv: {}
+
 
 pdf:
   replicas: 1
@@ -177,6 +185,8 @@ pdf:
       cpu: '1000m'
   podAnnotations: {}
   podLabels: {}
+  extraEnv: {}
+
 
 job:
   migrate:


### PR DESCRIPTION
### Description

This PR introduces the following changes:

1. **feat(helm): Support for `extraEnv` variables**  
   Added support for dynamic environment variables via the `extraEnv` section in the `values.yaml` for the following deployments:
   - `api`
   - `front`
   - `worker`
   - `events-worker`
   - `clock`
   - `pdf`

2. **fix(pvc): Resolved conditional issue in PVC template**  
   Fixed the logic error in the PersistentVolumeClaim template where multiple `not` conditions were incorrectly applied, causing template rendering issues. Now the PVC is correctly created when both `s3.enabled` and `minio.enabled` are set to `false`.
   
### Motivation

These changes allow users to configure additional environment variables without directly modifying the deployment templates, providing greater flexibility. For example, it was previously impossible to enable the `LAGO_DISABLE_WALLET_REFRESH` environment variable, despite it being documented. To avoid this issue and to allow for the dynamic addition of new arguments in the future without causing breaking changes, this approach offers a more sustainable solution.

The PVC issue was also resolved to ensure that the persistent volume is only created under the correct conditions.
