### PR TITLE
Fix S3 Configuration, Liveness Probe, and PVC Condition for Compatibility

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 13.2.2
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 18.2.1
-digest: sha256:d01903357743f9f6b319b84268e6821e941642672d5d85ea61b74986ad7bed1a
-generated: "2023-11-07T16:13:00.552026758+01:00"

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -251,13 +251,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
+          {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
+      {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -202,7 +202,7 @@ spec:
                       {{ end }}
             - name: LAGO_AWS_S3_REGION
               value: {{ if .Values.global.s3.enabled }}
-                        {{ .Values.global.s3.aws.region | quote }}
+                        {{ .Values.global.s3.region | quote }}
                       {{ else if .Values.minio.enabled }}
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -53,11 +53,11 @@ data:
 
   {{- if not .Values.global.existingSecret }}
   {{ if .Values.global.s3.enabled }}
-  {{ if .Values.global.s3.aws.accessKeyId }}
-  awsS3AccessKeyId: {{ .Values.global.s3.aws.accessKeyId | b64enc }}
+  {{ if .Values.global.s3.accessKeyId }}
+  awsS3AccessKeyId: {{ .Values.global.s3.accessKeyId | b64enc }}
   {{ end }}
-  {{ if .Values.global.s3.aws.secretAccessKey }}
-  awsS3SecretAccessKey: {{ .Values.global.s3.aws.secretAccessKey | b64enc }}
+  {{ if .Values.global.s3.secretAccessKey }}
+  awsS3SecretAccessKey: {{ .Values.global.s3.secretAccessKey | b64enc }}
   {{ end }}
   {{ if eq .Values.global.s3.provider "minio" }}
   {{ if .Values.global.s3.minio.accessKeyId }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -119,18 +119,18 @@ spec:
             {{ if .Values.global.s3.enabled }}
             - name: LAGO_USE_AWS_S3
               value: "true"
-            {{ if .Values.global.s3.aws.endpoint }}
+            {{ if .Values.global.s3.endpoint }}
             - name: LAGO_AWS_S3_ENDPOINT
-              value: {{ .Values.global.s3.aws.endpoint | quote }}
+              value: {{ .Values.global.s3.endpoint | quote }}
             {{ end }}
-            {{ if or .Values.global.s3.aws.accessKeyId .Values.global.existingSecret }}
+            {{ if or .Values.global.s3.accessKeyId .Values.global.existingSecret }}
             - name: LAGO_AWS_S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ include "secret-path" . }}
                   key: awsS3AccessKeyId
             {{ end }}
-            {{ if or .Values.global.s3.aws.secretAccessKey .Values.global.existingSecret }}
+            {{ if or .Values.global.s3.secretAccessKey .Values.global.existingSecret }}
             - name: LAGO_AWS_S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -138,9 +138,9 @@ spec:
                   key: awsS3SecretAccessKey
             {{ end }}
             - name: LAGO_AWS_S3_BUCKET
-              value: {{ .Values.global.s3.aws.bucket | quote }}
+              value: {{ .Values.global.s3.bucket | quote }}
             - name: LAGO_AWS_S3_REGION
-              value: {{ .Values.global.s3.aws.region | quote }}
+              value: {{ .Values.global.s3.region | quote }}
             {{ end }}
             {{ if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL


### PR DESCRIPTION
- S3 Configuration: Updated the S3 variable references by removing aws. to ensure consistency throughout the templates and to correctly support non-AWS S3-compatible services.
- Liveness Probe Duration: Increased the liveness probe period and timeout durations to ensure more robust health checks for the application.
- Persistent Volume Claim (PVC) Condition: Modified the condition logic in the PVC template to ensure proper handling of scenarios where S3 or Minio is not enabled.