### PR TITLE
chore(workflows): split release workflow into two for SOC 2 compliance

### DIFF
--- a/.github/workflows/creating_pr.yml
+++ b/.github/workflows/creating_pr.yml
@@ -29,13 +29,13 @@ jobs:
         run: |
           git checkout -b release/${{ github.event.inputs.tag }}
           git add Chart.yaml values.yaml
-          git commit -m "chore(release): update chart, appVersion, and values versions to ${{ github.event.inputs.tag }}"
+          git commit -m "chore(release): update to ${{ github.event.inputs.tag }}"
           git push origin release/${{ github.event.inputs.tag }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore(release): update chart, appVersion, and values versions to ${{ github.event.inputs.tag }}"
+          commit-message: "chore(release): update to ${{ github.event.inputs.tag }}"
           branch: release/${{ github.event.inputs.tag }}
           title: "Release ${{ github.event.inputs.tag }}"
           body: "This PR updates the chart versions to ${{ github.event.inputs.tag }}."

--- a/.github/workflows/creating_pr.yml
+++ b/.github/workflows/creating_pr.yml
@@ -1,0 +1,43 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+        default: '1.0.0'
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Update Chart and Values Versions
+        run: |
+          sed -i "s/^version:.*/version: ${{ github.event.inputs.tag }}/" Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: '${{ github.event.inputs.tag }}'/" Chart.yaml
+          sed -i "s/^version:.*/version: ${{ github.event.inputs.tag }}/" values.yaml
+
+      - name: Commit changes
+        run: |
+          git checkout -b release/${{ github.event.inputs.tag }}
+          git add Chart.yaml values.yaml
+          git commit -m "chore(release): update chart, appVersion, and values versions to ${{ github.event.inputs.tag }}"
+          git push origin release/${{ github.event.inputs.tag }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore(release): update chart, appVersion, and values versions to ${{ github.event.inputs.tag }}"
+          branch: release/${{ github.event.inputs.tag }}
+          title: "Release ${{ github.event.inputs.tag }}"
+          body: "This PR updates the chart versions to ${{ github.event.inputs.tag }}."
+          labels: release

--- a/.github/workflows/creating_pr.yml
+++ b/.github/workflows/creating_pr.yml
@@ -6,7 +6,6 @@ on:
       tag:
         description: 'Tag to release'
         required: true
-        default: '1.0.0'
 
 jobs:
   create-release-pr:
@@ -34,7 +33,7 @@ jobs:
           git push origin release/${{ github.event.inputs.tag }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore(release): update chart, appVersion, and values versions to ${{ github.event.inputs.tag }}"
           branch: release/${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Deploy to GitHub Pages
         run: |
           git checkout gh-pages
-          git pull origin gh-pages
+          git pull origin main --rebase --autostash
           helm repo index . --url https://getlago.github.io/charts
           git add .
           git commit -m "Update Helm repo index after release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
-name: Release Charts
+name: Release Charts on Merge
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to release'
-        required: true
-        default: '1.0.0'
+  pull_request:
+    types: [closed]
+    branches:
+      - main
 
 jobs:
-  release:
-    permissions:
-      contents: write
+  release-on-merge:
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,23 +20,14 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Lint Chart - Main chart
-        run: helm lint .  
+        run: helm lint .
 
       - name: Update Dependencies
-        run: helm dependency update .  
-
-      - name: Update Chart and Values Versions
-        run: |
-          sed -i "s/^version:.*/version: ${{ github.event.inputs.tag }}/" Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: '${{ github.event.inputs.tag }}'/" Chart.yaml
-          sed -i "s/^version:.*/version: ${{ github.event.inputs.tag }}/" values.yaml
-          git add Chart.yaml values.yaml
-          git commit -m "chore(release): update chart, appVersion, and values versions to ${{ github.event.inputs.tag }}"
-          git push origin main
+        run: helm dependency update .
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
@@ -49,8 +39,8 @@ jobs:
       - name: Deploy to GitHub Pages
         run: |
           git checkout gh-pages
-          git pull origin main --rebase --autostash 
+          git pull origin gh-pages
           helm repo index . --url https://getlago.github.io/charts
           git add .
-          git commit -m "Update Helm repo index for tag ${{ github.event.inputs.tag }}"
+          git commit -m "Update Helm repo index after release"
           git push origin gh-pages


### PR DESCRIPTION
This Pull Request separates the release workflow into two distinct workflows to comply with SOC 2 requirements : we can't directly commit on main even if its a bot.

- Workflow 1: Creates a release Pull Request to update version numbers.
- Workflow 2: Publishes the Helm charts upon merging the release PR into the main branch.

This ensures that all code changes are reviewed and approved before being merged, aligning with our compliance standards.