### PR TITLE
fix(action-pr): fixing creating of pull request

### DIFF
--- a/.github/workflows/creating_pr.yml
+++ b/.github/workflows/creating_pr.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           commit-message: "chore(release): update to ${{ github.event.inputs.tag }}"
           branch: release/${{ github.event.inputs.tag }}
+          base: main  
           title: "Release ${{ github.event.inputs.tag }}"
           body: "This PR updates the chart versions to ${{ github.event.inputs.tag }}."
           labels: release


### PR DESCRIPTION
All in the title to prevent error like :

```
  /usr/bin/git symbolic-ref HEAD --short
  release/1.14.0
  Working base is branch 'release/1.14.0'
  Error: The 'base' and 'branch' for a pull request must be different branches. Unable to continue.
```