### PR TITLE
Update Ingress Configuration and Documentation for LAGO_DOMAIN Path-Based Routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Helm chart deploys the Lago billing system with various optional dependenci
 
 ### Ingress Configuration for Path-Based Routing with LAGO_DOMAIN
 
-To streamline the deployment and eliminate CORS issues due to multiple domains, we now use path-based routing through a single variable, `LAGO_DOMAIN`. This setup enables the API and frontend to share the same domain (e.g., `https://lago.dev`) with distinct paths (`/api` for the backend and `/` for the frontend), thereby simplifying the deployment process for users.
+To streamline the deployment and eliminate CORS issues due to multiple domains, we now use path-based routing through a single variable, `LAGO_DOMAIN`. This setup enables the API and frontend to share the same domain (e.g., `https://lago.dev`) with distinct paths (`/api/` for the backend and `/` for the frontend), thereby simplifying the deployment process for users.
 
 #### NGINX Ingress Configuration
 
@@ -32,11 +32,11 @@ Here is the required configuration within the ingress:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/api(/|$)(.*) /$2 break;
+      rewrite ^/api/(.*) /$1 break;
 {{- end }}
 ```
 
-- **Explanation**: The `rewrite-target` annotation specifies that the request should be served from the root, while `configuration-snippet` applies a rewrite rule. This rule removes the `/api` prefix from incoming requests, allowing the backend to respond to requests as if they were directly under `/`.
+- **Explanation**: The `rewrite-target` annotation specifies that the request should be served from the root, while `configuration-snippet` applies a rewrite rule. This rule removes the `/api/` prefix from incoming requests, allowing the backend to respond to requests as if they were directly under `/`.
 
 #### Non-NGINX Ingress Controllers
 

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -82,9 +82,17 @@ spec:
               {{- $pdfHost := printf "%s-pdf-svc.%s" .Release.Name .Release.Namespace}}
               value: {{ printf "http://%s:%v" $pdfHost .Values.pdf.service.port | quote }}
             - name: LAGO_API_URL
-              value: {{ required "apiUrl value is required" .Values.apiUrl | quote }}
+              value: {{- if .Values.LAGO_DOMAIN }}
+                        "https://{{ .Values.LAGO_DOMAIN }}/api"
+                      {{- else }}
+                        {{ required "apiUrl value is required" .Values.apiUrl | quote }}
+                      {{- end }}
             - name: LAGO_FRONT_URL
-              value: {{ required "frontUrl value is required" .Values.frontUrl | quote }}
+              value: {{- if .Values.LAGO_DOMAIN }}
+                        "https://{{ .Values.LAGO_DOMAIN }}"
+                      {{- else }}
+                        {{ required "frontUrl value is required" .Values.frontUrl | quote }}
+                      {{- end }}
             - name: LAGO_SIDEKIQ_WEB
               value: {{ .Values.api.sidekiqWeb.enabled | quote }}
             - name: RAILS_LOG_TO_STDOUT

--- a/templates/front-deployment.yaml
+++ b/templates/front-deployment.yaml
@@ -24,11 +24,19 @@ spec:
       containers:
         - env:
             - name: API_URL
-              value: {{ .Values.apiUrl | quote }}
+              value: {{- if .Values.LAGO_DOMAIN }}
+                        "https://{{ .Values.LAGO_DOMAIN }}/api"
+                      {{- else }}
+                        {{ required "apiUrl value is required" .Values.apiUrl | quote }}
+                      {{- end }}
             - name: APP_ENV
               value: production
             - name: CODEGEN_API
-              value: {{ .Values.apiUrl | quote }}
+              value: {{- if .Values.LAGO_DOMAIN }}
+                        "https://{{ .Values.LAGO_DOMAIN }}/api"
+                      {{- else }}
+                        {{ required "apiUrl value is required" .Values.apiUrl | quote }}
+                      {{- end }}
             - name: LAGO_DISABLE_SIGNUP
               value: {{ not .Values.global.signup.enabled | quote }}
             {{- with .Values.front.extraEnv }}

--- a/templates/ingress-backend.yaml
+++ b/templates/ingress-backend.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.global.ingress.enabled (hasKey .Values "LAGO_DOMAIN") (ne .Values.LAGO_DOMAIN "") }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-api-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+  {{- if .Values.global.ingress.annotations }}
+    {{- with .Values.global.ingress.annotations }}
+      {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+  - host: {{ .Values.LAGO_DOMAIN }}
+    http:
+      paths:
+      - path: /api/(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-api-svc
+            port:
+              number: {{ .Values.api.service.port }}
+  tls:
+  - hosts:
+      - {{ .Values.LAGO_DOMAIN }}
+    secretName: {{ .Release.Name }}-ingress-secret
+{{- end }}

--- a/templates/ingress-frontend.yaml
+++ b/templates/ingress-frontend.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.global.ingress.enabled (hasKey .Values "LAGO_DOMAIN") (ne .Values.LAGO_DOMAIN "") }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-front-ingress
+  annotations:
+  {{- if .Values.global.ingress.annotations }}
+    {{- with .Values.global.ingress.annotations }}
+      {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+  - host: {{ .Values.LAGO_DOMAIN }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-front-svc
+            port:
+              number: {{ .Values.front.service.port }}
+  tls:
+  - hosts:
+      - {{ .Values.LAGO_DOMAIN }}
+    secretName: {{ .Release.Name }}-ingress-secret
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,83 +1,38 @@
-{{ if .Values.global.ingress.enabled }}
+{{- if and .Values.global.ingress.enabled (or (not (hasKey .Values "LAGO_DOMAIN")) (eq .Values.LAGO_DOMAIN "")) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   annotations:
-{{- if .Values.global.ingress.annotations }}
+{{ if .Values.global.ingress.annotations }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
-{{- end }}
-{{- if .Values.LAGO_DOMAIN }}
-    # We need to rewrite API requests so that the backend does not see the "/api" prefix in the URL.
-    # It is essential to enable "configuration-snippet" in the NGINX controller for this rewrite to function correctly.
-    # If a different ingress controller is used, ensure it is configured to handle the rewrite with appropriate annotations.
-    # Additional annotations when LAGO_DOMAIN is set
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/api/(.*) /$1 break;
-{{- end }}
+{{ end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className }}
   tls:
-{{- if .Values.LAGO_DOMAIN }}
-    - hosts:
-        - {{ .Values.LAGO_DOMAIN }}
-      secretName: {{ .Release.Name }}-ingress-secret
-{{- else }}
-    - hosts:
-{{- if .Values.global.ingress.frontHostname }}
-        - {{ .Values.global.ingress.frontHostname }}
-{{- end }}
-{{- if .Values.global.ingress.apiHostname }}
-        - {{ .Values.global.ingress.apiHostname }}
-{{- end }}
-      secretName: {{ .Release.Name }}-ingress-secret
-{{- end }}
+  - hosts:
+    - {{ .Values.global.ingress.frontHostname }}
+    - {{ .Values.global.ingress.apiHostname }}
+    secretName: {{ .Release.Name }}-ingress-secret
   rules:
-{{- if .Values.LAGO_DOMAIN }}
-    - host: {{ .Values.LAGO_DOMAIN }}
-      http:
-        paths:
-          - path: /api/
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Release.Name }}-api-svc
-                port:
-                  number: {{ .Values.api.service.port }}
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Release.Name }}-front-svc
-                port:
-                  number: {{ .Values.front.service.port }}
-{{- else }}
-{{- if .Values.global.ingress.frontHostname }}
-    - host: {{ .Values.global.ingress.frontHostname }}
-      http:
-        paths:
-          - path: 
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ .Release.Name }}-front-svc
-                port:
-                  number: {{ .Values.front.service.port }}
-{{- end }}
-{{- if .Values.global.ingress.apiHostname }}
-    - host: {{ .Values.global.ingress.apiHostname }}
-      http:
-        paths:
-          - path: 
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ .Release.Name }}-api-svc
-                port:
-                  number: {{ .Values.api.service.port }}
-{{- end }}
-{{- end }}
+  - host: {{ .Values.global.ingress.frontHostname }}
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ .Release.Name }}-front-svc
+            port:
+              number: {{ .Values.front.service.port }}
+  - host: {{ .Values.global.ingress.apiHostname }}
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ .Release.Name }}-api-svc
+            port:
+              number: {{ .Values.api.service.port }}
 {{ end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
 {{- if .Values.global.ingress.annotations }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | trim | nindent 4 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     # Additional annotations when LAGO_DOMAIN is set
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/api(/|$)(.*) /$2 break;
+      rewrite ^/api/(.*) /$1 break;
 {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className }}
@@ -40,7 +40,7 @@ spec:
     - host: {{ .Values.LAGO_DOMAIN }}
       http:
         paths:
-          - path: /api
+          - path: /api/
             pathType: Prefix
             backend:
               service:
@@ -59,7 +59,7 @@ spec:
     - host: {{ .Values.global.ingress.frontHostname }}
       http:
         paths:
-          - path: /
+          - path: 
             pathType: ImplementationSpecific
             backend:
               service:
@@ -71,7 +71,7 @@ spec:
     - host: {{ .Values.global.ingress.apiHostname }}
       http:
         paths:
-          - path: /
+          - path: 
             pathType: ImplementationSpecific
             backend:
               service:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,35 +4,69 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   annotations:
-{{ if .Values.global.ingress.annotations }}
+{{- if .Values.global.ingress.annotations }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
-{{ end }}
+{{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className }}
   tls:
-  - hosts:
-    - {{ .Values.global.ingress.frontHostname }}
-    - {{ .Values.global.ingress.apiHostname }}
-    secretName: {{ .Release.Name }}-ingress-secret
+{{- if .Values.LAGO_DOMAIN }}
+    - hosts:
+        - {{ .Values.LAGO_DOMAIN }}
+      secretName: {{ .Release.Name }}-ingress-secret
+{{- else }}
+    - hosts:
+{{- if .Values.global.ingress.frontHostname }}
+        - {{ .Values.global.ingress.frontHostname }}
+{{- end }}
+{{- if .Values.global.ingress.apiHostname }}
+        - {{ .Values.global.ingress.apiHostname }}
+{{- end }}
+      secretName: {{ .Release.Name }}-ingress-secret
+{{- end }}
   rules:
-  - host: {{ .Values.global.ingress.frontHostname }}
-    http:
-      paths:
-      - pathType: ImplementationSpecific
-        backend:
-          service:
-            name: {{ .Release.Name }}-front-svc
-            port:
-              number: {{ .Values.front.service.port }}
-  - host: {{ .Values.global.ingress.apiHostname }}
-    http:
-      paths:
-      - pathType: ImplementationSpecific
-        backend:
-          service:
-            name: {{ .Release.Name }}-api-svc
-            port:
-              number: {{ .Values.api.service.port }}
+{{- if .Values.LAGO_DOMAIN }}
+    - host: {{ .Values.LAGO_DOMAIN }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-api-svc
+                port:
+                  number: {{ .Values.api.service.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-front-svc
+                port:
+                  number: {{ .Values.front.service.port }}
+{{- else }}
+{{- if .Values.global.ingress.frontHostname }}
+    - host: {{ .Values.global.ingress.frontHostname }}
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ .Release.Name }}-front-svc
+                port:
+                  number: {{ .Values.front.service.port }}
+{{- end }}
+{{- if .Values.global.ingress.apiHostname }}
+    - host: {{ .Values.global.ingress.apiHostname }}
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ .Release.Name }}-api-svc
+                port:
+                  number: {{ .Values.api.service.port }}
+{{- end }}
+{{- end }}
 {{ end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -9,6 +9,12 @@ metadata:
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if .Values.LAGO_DOMAIN }}
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/api(/|$)(.*) /$2 break;
+{{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className }}
   tls:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 {{- end }}
 {{- if .Values.LAGO_DOMAIN }}
+    # We need to rewrite API requests so that the backend does not see the "/api" prefix in the URL.
+    # It is essential to enable "configuration-snippet" in the NGINX controller for this rewrite to function correctly.
+    # If a different ingress controller is used, ensure it is configured to handle the rewrite with appropriate annotations.
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,6 +4,7 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   annotations:
+    kubernetes.io/ingress.class: nginx
 {{- if .Values.global.ingress.annotations }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | trim | nindent 4 }}
@@ -13,7 +14,7 @@ metadata:
     # We need to rewrite API requests so that the backend does not see the "/api" prefix in the URL.
     # It is essential to enable "configuration-snippet" in the NGINX controller for this rewrite to function correctly.
     # If a different ingress controller is used, ensure it is configured to handle the rewrite with appropriate annotations.
-    kubernetes.io/ingress.class: nginx
+    # Additional annotations when LAGO_DOMAIN is set
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite ^/api(/|$)(.*) /$2 break;
@@ -59,7 +60,8 @@ spec:
     - host: {{ .Values.global.ingress.frontHostname }}
       http:
         paths:
-          - pathType: ImplementationSpecific
+          - path: /
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ .Release.Name }}-front-svc
@@ -70,7 +72,8 @@ spec:
     - host: {{ .Values.global.ingress.apiHostname }}
       http:
         paths:
-          - pathType: ImplementationSpecific
+          - path: /
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ .Release.Name }}-api-svc

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -65,9 +65,17 @@ spec:
               {{- $pdfHost := printf "%s-pdf-svc.%s" .Release.Name .Release.Namespace}}
               value: {{ printf "http://%s:%v" $pdfHost .Values.pdf.service.port | quote }}
             - name: LAGO_API_URL
-              value: {{ required "apiUrl value is required" .Values.apiUrl | quote }}
+              value: {{- if .Values.LAGO_DOMAIN }}
+                        "https://{{ .Values.LAGO_DOMAIN }}/api"
+                      {{- else }}
+                        {{ required "apiUrl value is required" .Values.apiUrl | quote }}
+                      {{- end }}
             - name: LAGO_FRONT_URL
-              value: {{ required "frontUrl value is required" .Values.frontUrl | quote }}
+              value: {{- if .Values.LAGO_DOMAIN }}
+                        "https://{{ .Values.LAGO_DOMAIN }}"
+                      {{- else }}
+                        {{ required "frontUrl value is required" .Values.frontUrl | quote }}
+                      {{- end }}
             - name: RAILS_LOG_TO_STDOUT
               value: {{ .Values.worker.rails.logStdout | quote }}
             {{- with .Values.worker.extraEnv }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,15 @@
 version: 1.15.0
 
+
+#Note: If LAGO_DOMAIN is set, these variables (apiUrl & frontUrl) will be overridden.
 # apiUrl: mydomain.dev
 # frontUrl: mydomain.dev
+
+# By setting the LAGO_DOMAIN variable, your application will be available directly on the specified domain. 
+# For example, if LAGO_DOMAIN is set to getmydomain.dev, your GetLago instance will be accessible at https://getmydomain.dev,
+# and your API at https://getmydomain.dev/api/api/v1. Note that adding this variable changes the domain structure:
+# your application will no longer be accessible at api.getmydomain.dev and app.getmydomain.dev.
+#LAGO_DOMAIN: mydomain.dev
 
 # Only for Development, Staging or PoC, you should use a managed Redis instance for Production
 redis:
@@ -79,6 +87,7 @@ global:
 
   ingress:
     enabled: false
+    #Note: If LAGO_DOMAIN is set, frontHostname & apiHostname will be ignored.
     #frontHostname:
     #apiHostname:
     #className:
@@ -209,7 +218,7 @@ minio:
   enabled: false
   # replicas: 2
   # fullnameOverride: "my-lago-minio"
-  # endpoint: "http://minio.lago.dev"
+  # endpoint: "http://minio.mydomain.dev"
   # nameOverride: "minio"
   # resources:
   #   requests:
@@ -227,7 +236,7 @@ minio:
   #   annotations: {}
   #   path: /
   #   hosts:
-  #     - minio.lago.dev
+  #     - minio.mydomain.dev
   #   tls: []
   # Note : only the first one will be used
   # buckets:


### PR DESCRIPTION
**Title:** Update Ingress Configuration and Documentation for LAGO_DOMAIN Path-Based Routing

**Description:**
This PR updates both the Ingress configurations and documentation to implement a path-based routing setup with `LAGO_DOMAIN`. Key changes include:

- Refactored Ingress files:
  - Split Ingress into separate configurations for frontend and API.
  - Applied path-based routing, ensuring API requests use the `/api/` prefix.
  - Added rewrite rules to strip the `/api/` prefix before requests reach the backend.
- Documentation update:
  - Provided instructions for setting up path-based routing with NGINX and alternative ingress controllers.
  - Emphasized the importance of the `/api/` prefix to prevent routing conflicts with frontend paths.
