### PR TITLE
chore(release): update GitHub workflow and Helm config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Deploy to GitHub Pages
         if: env.has_release_label == 'true'
         run: |
-          helm package . --destination charts/
-          helm repo index . --url https://getlago.github.io/charts
+          helm package . --destination artifacts/
+          helm repo index . --url https://charts.getlago.com/
           git add .
           git commit -m "Update Helm repo index after release"
           git pull
@@ -73,12 +73,12 @@ jobs:
 
       - name: Create GitHub Release
         if: env.has_release_label == 'true'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: "v${{ env.version }}"
-          release_name: "Release v${{ env.version }}"
-          body: "Release of version v${{ env.version }}"
+          name: "Release v${{ env.version }}"
+          generate_release_notes: true
           draft: false
           prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.helmignore
+++ b/.helmignore
@@ -3,3 +3,4 @@
 .gitignore
 LICENSE
 README.md
+artifacts/

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,10 @@
 version: 1.15.0
 
-# apiUrl: mydomain.dev
-# frontUrl: mydomain.dev
+# Required: Set the URLs for your API and Frontend services
+# Replace these placeholders with the actual domain names.
+apiUrl: "" # Example: https://api.mydomain.dev
+frontUrl: "" # Example: https://app.mydomain.dev
+
 
 # Only for Development, Staging or PoC, you should use a managed Redis instance for Production
 redis:


### PR DESCRIPTION
## Description

This pull request introduces several changes to the GitHub Action workflow:

- **Change of release files location**: The release files are now stored in the `artifacts/` directory instead of `charts/`. This prevents conflicts when creating Helm packages due to dependencies within Helm.

- **Added default values for `apiUrl` and `frontUrl`**: Previously, if these values were commented out, Helm would ignore them, causing the following error:

```bash
$ helm template my-lago lago/lago --version 1.15.0 --set lago.apiUrl=https://api.domain.tld/ --set lago.frontUrl=https://app.domain.tld/ --debug install.go:218: [debug] Original chart version: "1.15.0" install.go:235: [debug] CHART PATH: /home/pb/.cache/helm/repository/lago-1.15.0.tgz

Error: execution error at (lago/templates/worker-deployment.yaml:68:24): apiUrl value is required helm.go:84: [debug] execution error at (lago/templates/worker-deployment.yaml:68:24): apiUrl value is required
```

This should fix issue #120 


- **Added Helm packages to `.helmignore`**: Helm was previously including these packages inside new packages by default, which quickly inflated the package size. This led to the following error:

```bash
charts helm install my-lago lago2/lago --version 1.15.4 --values value_old.yaml
Error: INSTALLATION FAILED: create: failed to create: Request entity too large: limit is 3145728
```


