### PR TITLE
bug(WebhookWorker) - make sure LAGO_API_URL is set in webhook-worker

### DIFF
--- a/templates/webhook-worker-deployment.yaml
+++ b/templates/webhook-worker-deployment.yaml
@@ -110,6 +110,8 @@ spec:
               value: {{ .Values.billingWorker.enabled | quote }}
             - name: SIDEKIQ_CLOCK
               value: {{ .Values.clockWorker.enabled | quote }}
+            - name: LAGO_API_URL
+              value: {{ required "apiUrl value is required" .Values.apiUrl | quote }}
             - name: LAGO_LOG_LEVEL
               value: {{ .Values.webhookWorker.rails.logLevel | quote }}
             {{- with .Values.webhookWorker.extraEnv }}


### PR DESCRIPTION
## Description

We sometimes call `file_url` from Invoice in web hooks, this requires this env var to be set.