### PR TITLE
fix: fix encryption secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,15 +212,19 @@ If you use an existing secret, the following keys are expected:
 
 - `databaseUrl` (required)
 - `redisUrl` (required)
-- `encryptionPrimaryKey` (required)
-- `encryptionDeterministicKey` (required)
-- `encryptionKeyDerivationSalt` (required)
 - `awsS3AccessKeyId` (optional)
 - `awsS3SecretAccessKey` (optional)
 - `smtpUsername` (optional)
 - `smtpPassword` (optional)
 - `googleAuthClientId` (optional)
 - `googleAuthClientSecret` (optionals)
+
+If you want to provide an existing secret for the encryption keys, you can also set the `encryption.existingSecret` parameter to the name of the secret.
+The following keys are expected:
+
+- `encryptionPrimaryKey` (required)
+- `encryptionDeterministicKey` (required)
+- `encryptionKeyDerivationSalt` (required)
 
 
 ## Storage Recommendation

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.22.2"
+appVersion: "1.23.0"
 description: the Lago open source billing app
 name: lago
 version: 1.21.3

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "1.22.1"
+appVersion: "1.22.2"
 description: the Lago open source billing app
 name: lago
-version: 1.21.2
+version: 1.21.3
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/charts/lago/templates/_helpers.tpl
+++ b/charts/lago/templates/_helpers.tpl
@@ -6,6 +6,14 @@
 {{- end }}
 {{- end}}
 
+{{- define "encryption-secret-path" }}
+{{- if .Values.encryption.existingSecret -}}
+{{ .Values.encryption.existingSecret }}
+{{- else -}}
+{{ .Release.Name }}-secrets
+{{- end }}
+{{- end}}
+
 {{- define "kubectlVersion" }}
 {{- if .Values.global.kubectlVersion -}}
 {{ .Values.global.kubectlVersion }}

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -114,17 +114,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}

--- a/charts/lago/templates/billing-worker-deployment.yaml
+++ b/charts/lago/templates/billing-worker-deployment.yaml
@@ -95,17 +95,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}

--- a/charts/lago/templates/clock-deployment.yaml
+++ b/charts/lago/templates/clock-deployment.yaml
@@ -87,17 +87,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: LAGO_LOG_LEVEL
               value: {{ .Values.clock.rails.logLevel | quote }}

--- a/charts/lago/templates/clock-worker-deployment.yaml
+++ b/charts/lago/templates/clock-worker-deployment.yaml
@@ -95,17 +95,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}

--- a/charts/lago/templates/events-worker-deployment.yaml
+++ b/charts/lago/templates/events-worker-deployment.yaml
@@ -87,17 +87,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: DATABASE_POOL
               value: {{ .Values.eventsWorker.rails.sidekiqConcurrency | quote }}

--- a/charts/lago/templates/pdf-worker-deployment.yaml
+++ b/charts/lago/templates/pdf-worker-deployment.yaml
@@ -95,17 +95,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}

--- a/charts/lago/templates/secrets.yaml
+++ b/charts/lago/templates/secrets.yaml
@@ -16,7 +16,7 @@ data:
   {{ $secretKeyBase := (get $secretData "secretKeyBase") | default (randAlphaNum 64 | b64enc | b64enc) }}
   secretKeyBase: {{ $secretKeyBase | quote }}
 
-  {{- if not .Values.global.existingSecret }}
+  {{- if not .Values.encryption.existingSecret }}
   {{ $encryptionPrimaryKey := (get $secretData "encryptionPrimaryKey") | default (randAlphaNum 32 | b64enc | b64enc) }}
   encryptionPrimaryKey: {{ $encryptionPrimaryKey | quote }}
 

--- a/charts/lago/templates/webhook-worker-deployment.yaml
+++ b/charts/lago/templates/webhook-worker-deployment.yaml
@@ -88,17 +88,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: DATABASE_POOL
               value: {{ .Values.webhookWorker.rails.sidekiqConcurrency | quote }}

--- a/charts/lago/templates/worker-deployment.yaml
+++ b/charts/lago/templates/worker-deployment.yaml
@@ -94,17 +94,17 @@ spec:
             - name: ENCRYPTION_DETERMINISTIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionDeterministicKey
             - name: ENCRYPTION_KEY_DERIVATION_SALT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionKeyDerivationSalt
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secrets
+                  name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -1,4 +1,4 @@
-version: 1.22.1
+version: 1.22.2
 
 # Required: Set the URLs for your API and Frontend services
 # Replace these placeholders with the actual domain names.
@@ -97,6 +97,13 @@ global:
     enabled: false
     egress: []
     ingress: []
+
+encryption:
+  # The following fields are required:
+  #  - encryptionPrimaryKey:
+  #  - encryptionDeterministicKey:
+  #  - encryptionKeyDerivationSalt:
+  existingSecret:
 
   # serviceAccountName:
 

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -1,4 +1,4 @@
-version: 1.22.2
+version: 1.23.0
 
 # Required: Set the URLs for your API and Frontend services
 # Replace these placeholders with the actual domain names.


### PR DESCRIPTION
This PR resolves the issue [Wrong encryption keys used when setting global.existingSecret](https://github.com/getlago/lago-helm-charts/issues/163), introduced by the commit [fix(secrets): Add encryption keys under existingSecrets](https://github.com/getlago/lago-helm-charts/commit/d1ace4fd7373d02c1740e2e4ed5a169ce1a7e53f). It ensures that encryption keys are correctly sourced from the provided existing secret.

Additionally, the previous commit introduced a breaking change for users already utilizing an existing secret, as it inadvertently caused the loss of encryption keys stored in `{{ .Release.Name }}-secrets` upon chart updates. To address this, the PR introduces distinct fields for `existingSecret`: one for global purposes and another specifically for encryption purposes, thus preserving existing user configurations during upgrades.