### PR TITLE
feat(pdf): Add env var to disable generating pdfs

### DIFF
--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.22.1"
 description: the Lago open source billing app
 name: lago
-version: 1.21.2
+version: 1.21.3
 dependencies:
   - name: postgresql
     version: "13.2.2"

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -130,6 +130,8 @@ spec:
               value: {{ not .Values.global.segment.enabled | quote }}
             - name: LAGO_DISABLE_SIGNUP
               value: {{ not .Values.global.signup.enabled | quote }}
+            - name: LAGO_DISABLE_PDF_GENERATION
+              value: {{ not .Values.global.pdf.enabled | quote }}
             - name: DATABASE_POOL
               value: {{ mul .Values.api.rails.maxThreads .Values.api.rails.webConcurrency | quote }}
             - name: RAILS_MAX_THREADS

--- a/charts/lago/templates/billing-worker-deployment.yaml
+++ b/charts/lago/templates/billing-worker-deployment.yaml
@@ -109,6 +109,8 @@ spec:
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}
+            - name: LAGO_DISABLE_PDF_GENERATION
+              value: {{ not .Values.global.pdf.enabled | quote }}
             - name: DATABASE_POOL
               value: {{ (mul .Values.billingWorker.rails.sidekiqConcurrency 2) | quote }}
             - name: SIDEKIQ_CONCURRENCY

--- a/charts/lago/templates/clock-worker-deployment.yaml
+++ b/charts/lago/templates/clock-worker-deployment.yaml
@@ -109,6 +109,8 @@ spec:
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}
+            - name: LAGO_DISABLE_PDF_GENERATION
+              value: {{ not .Values.global.pdf.enabled | quote }}
             - name: DATABASE_POOL
               value: {{ .Values.billingWorker.rails.sidekiqConcurrency | quote }}
             - name: SIDEKIQ_CONCURRENCY

--- a/charts/lago/templates/front-deployment.yaml
+++ b/charts/lago/templates/front-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.apiUrl | quote }}
             - name: LAGO_DISABLE_SIGNUP
               value: {{ not .Values.global.signup.enabled | quote }}
+            - name: LAGO_DISABLE_PDF_GENERATION
+              value: {{ not .Values.global.pdf.enabled | quote }}
             {{- with .Values.front.extraEnv }}
             {{- range $key, $value := . }}
             - name: {{ $key }}

--- a/charts/lago/templates/pdf-worker-deployment.yaml
+++ b/charts/lago/templates/pdf-worker-deployment.yaml
@@ -109,6 +109,8 @@ spec:
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}
+            - name: LAGO_DISABLE_PDF_GENERATION
+              value: {{ not .Values.global.pdf.enabled | quote }}
             - name: DATABASE_POOL
               value: {{ .Values.pdfWorker.rails.sidekiqConcurrency | quote }}
             - name: SIDEKIQ_CONCURRENCY

--- a/charts/lago/templates/worker-deployment.yaml
+++ b/charts/lago/templates/worker-deployment.yaml
@@ -108,6 +108,8 @@ spec:
                   key: encryptionPrimaryKey
             - name: LAGO_DISABLE_SEGMENT
               value: {{ not .Values.global.segment.enabled | quote }}
+            - name: LAGO_DISABLE_PDF_GENERATION
+              value: {{ not .Values.global.pdf.enabled | quote }}
             - name: DATABASE_POOL
               value: {{ .Values.worker.rails.sidekiqConcurrency | quote }}
             - name: SIDEKIQ_CONCURRENCY

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -80,6 +80,10 @@ global:
   signup:
     enabled: true
 
+  # You can disable Lago's pdf generation
+  pdf:
+    enabled: true
+
   googleAuth:
     # clientId and clientSecret are not required here if using existingSecret
     enabled: false


### PR DESCRIPTION
## Context

Some clients don't need pdfs of invoices, credit notes and payment receipts.

## Description

This PR adds an ENV var to disable generating pdfs: `LAGO_DISABLE_PDF_GENERATION`
