### PR TITLE
feat(clickhouse): Add support for clickhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ You can use the provided `Taskfile.yaml` to easily set up a local development en
 | `global.kubectl.imageRegistry`   | Docker registry with kubectl image (for init containers)                                                | `docker.io`       |
 | `global.kubectl.imageRepository` | Docker repository with kubectl image (for init containers)                                              | `rancher/kubectl` |
 | `global.kubectl.imageTag`        | Tag of kubectl Docker image (for init containers) - if unset (default) it is set to k8s cluster version | `""`              |
+| `global.clickhouse.enabled`                | Enable ClickHouse integration within Lago                                      | `false`             |
+| `global.clickhouse.kafka.tls`              | Enable TLS support for Kafka when using ClickHouse                             | `true `             |
+| `global.clickhouse.kafka.saslMechanisms`   | Kafka SASL mechanism                                                           | `"SCRAM-SHA-512"`   |
+| `global.clickhouse.kafka.securityProtocol` | Kafka Security protocol                                                        | `"SASL_SSL"`        |
+| `global.clickhouse.kafka.consumerGroup`    | Kafka consumer group name                                                      | `"events_consumer"` |
+| `global.clickhouse.kafka.boostrapServers`  | *(Required)* Kafka list of endpoints                                           | `[]`                |
+| `global.clickhouse.kafka.topics`           | Dictionary of Kafka topics                                                     | {...}               |
 
 ### Frontend Configuration
 
@@ -139,6 +146,39 @@ You can use the provided `Taskfile.yaml` to easily set up a local development en
 | `worker.livenessProbe.periodSeconds`       | Liveness probe period                            | `10`      |
 | `worker.livenessProbe.timeoutSeconds`      | Liveness probe timeout                           | `1`       |
 | `worker.livenessProbe.failureThreshold`    | Liveness probe failure threshold                | `3`       |
+
+
+### Events Consumer Configuration
+
+| Parameter                                  | Description                                         | Default        |
+|--------------------------------------------|-----------------------------------------------------|----------------|
+| `eventsConsumer.databasePool`              | Size of the database connection pool                | `10`           |
+| `eventsConsumer.tolerations`               | Pod tolerations for Events Consumer pods            | `[]`           |
+| `eventsConsumer.nodeSelector`              | Node selector for Events Consumer pods              | `{}`           |
+| `eventsConsumer.affinity`                  | Affinity rules for Events Consumer pods             | `{}`           |
+| `eventsConsumer.rails.env`                 | Events Consumer environment                         | `production`   |
+| `eventsConsumer.rails.logStdout`           | Enable or disable logging to stdout                 | `true`         |
+| `eventsConsumer.rails.logLevel`            | Log level for the Rails app                         | `error`        |
+| `eventsConsumer.resources.requests.memory` | Memory request for Events Consumer                  | `1Gi`          |
+| `eventsConsumer.resources.requests.cpu`    | CPU request for Events Consumer                     | `1100m`        |
+| `eventsConsumer.podAnnotations`            | Annotations to add to the Events Consumer pod       | `{}`           |
+| `eventsConsumer.podLabels`                 | Labels to add to the Events Consumer pod            | `{}`           |
+| `eventsConsumer.extraEnv`                  | Additional environment variables for pods           | `{}`           |
+
+### Events Processor Configuration
+
+| Parameter                                   | Description                                         | Default        |
+|---------------------------------------------|-----------------------------------------------------|----------------|
+| `eventsProcessor.databasePool`              | Size of the database connection pool                | `10`           |
+| `eventsProcessor.env`                       | Events Processor environment                        | `production`   |
+| `eventsProcessor.tolerations`               | Pod tolerations for Events Processor pods           | `[]`           |
+| `eventsProcessor.nodeSelector`              | Node selector for Events Processor pods             | `{}`           |
+| `eventsProcessor.affinity`                  | Affinity rules for Events Processor pods            | `{}`           |
+| `eventsProcessor.resources.requests.memory` | Memory request for Events Processor                 | `1Gi`          |
+| `eventsProcessor.resources.requests.cpu`    | CPU request for Events Processor                    | `1100m`        |
+| `eventsProcessor.podAnnotations`            | Annotations to add to the Events Processor pod      | `{}`           |
+| `eventsProcessor.podLabels`                 | Labels to add to the Events Processor pod           | `{}`           |
+| `eventsProcessor.extraEnv`                  | Additional environment variables for pods           | `{}`           |
 
 ### Events Worker Configuration
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -38,3 +38,20 @@ tasks:
       - kubectl apply -f charts/lago/ci/postgres.yml
       - kubectl apply -f charts/lago/ci/redis.yml
       - ct install --config ct.yaml --namespace default
+
+  render:
+    cmd: >
+      helm template lago ./charts/lago
+      --set apiUrl=http://localhost:3000
+      --set frontUrl=http://localhost:3000
+      --set global.databaseUrl=postgres://postgres:postgres@localhost:5432/postgres
+      --set global.redisUrl=redis://localhost:6379
+      {{join " " .CLI_ARGS_LIST}}
+
+  render:clickhouse:
+    cmds:
+      - task: render
+        vars:
+          CLI_ARGS_LIST: >
+            --set global.clickhouse.enabled=true {{.CLI_ARGS}}
+            --set global.clickhouse.kafka.bootstrapServers[0]=kafka-server:9092

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.26.3
+version: 1.27.0
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/ci/clickhouse.yaml
+++ b/charts/lago/ci/clickhouse.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+      - name: clickhouse
+        image: clickhouse/clickhouse-server:25.6-alpine
+        ports:
+        - containerPort: 9000
+        - containerPort: 8123
+        readinessProbe:
+          exec:
+            command:
+            - clickhouse-client
+            - --password
+            - default
+            - -q
+            - "SELECT 1"
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 5
+        volumeMounts:
+        - name: clickhouse-config
+          mountPath: /etc/clickhouse-server/config.d/config.xml
+          subPath: config.xml
+        - name: clickhouse-config
+          mountPath: /etc/clickhouse-server/users.d/users.xml
+          subPath: users.xml
+      volumes:
+      - name: clickhouse-config
+        configMap:
+          name: clickhouse-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+spec:
+  type: ClusterIP
+  selector:
+    app: clickhouse
+  ports:
+  - port: 9000
+    targetPort: 9000
+    name: tcp
+  - port: 8123
+    targetPort: 8123
+    name: http
+---
+apiVersion: v1
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: clickhouse-config
+data:
+  config.xml: |
+    <clickhouse replace="true">
+        <logger>
+            <level>debug</level>
+            <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+            <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+            <size>1000M</size>
+            <count>3</count>
+        </logger>
+        <display_name>clickhouse_dev</display_name>
+        <listen_host>0.0.0.0</listen_host>
+        <http_port>8123</http_port>
+        <tcp_port>9000</tcp_port>
+        <user_directories>
+            <users_xml>
+                <path>users.xml</path>
+            </users_xml>
+            <local_directory>
+                <path>/var/lib/clickhouse/access/</path>
+            </local_directory>
+        </user_directories>
+    </clickhouse>
+  users.xml: |
+    <?xml version="1.0"?>
+    <clickhouse replace="true">
+        <profiles>
+            <default>
+                <max_memory_usage>10000000000</max_memory_usage>
+                <use_uncompressed_cache>0</use_uncompressed_cache>
+                <load_balancing>in_order</load_balancing>
+                <log_queries>1</log_queries>
+            </default>
+        </profiles>
+        <users>
+            <default>
+                <access_management>1</access_management>
+                <profile>default</profile>
+                <password>default</password>
+                <networks>
+                    <ip>::/0</ip>
+                </networks>
+                <quota>default</quota>
+                <access_management>1</access_management>
+                <named_collection_control>1</named_collection_control>
+                <show_named_collections>1</show_named_collections>
+                <show_named_collections_secrets>1</show_named_collections_secrets>
+            </default>
+        </users>
+        <quotas>
+            <default>
+                <interval>
+                    <duration>3600</duration>
+                    <queries>0</queries>
+                    <errors>0</errors>
+                    <result_rows>0</result_rows>
+                    <read_rows>0</read_rows>
+                    <execution_time>0</execution_time>
+                </interval>
+            </default>
+        </quotas>
+    </clickhouse>

--- a/charts/lago/ci/redpanda.yaml
+++ b/charts/lago/ci/redpanda.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redpanda
+  template:
+    metadata:
+      labels:
+        app: redpanda
+    spec:
+      containers:
+      - name: redpanda
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.9
+        args:
+        - redpanda start
+        - --smp 1
+        - --overprovisioned
+        - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+        - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+        ports:
+        - containerPort: 9092
+        readinessProbe:
+          httpGet:
+            path: /v1/status/ready
+            port: 9644
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+spec:
+  type: ClusterIP
+  selector:
+    app: redpanda
+  ports:
+  - port: 9092
+    targetPort: 9092

--- a/charts/lago/examples/events-consumer/README.md
+++ b/charts/lago/examples/events-consumer/README.md
@@ -1,0 +1,65 @@
+# Lago Events Processing - Example Configurations
+
+This directory contains example configurations for deploying Lago's events processing components.
+In this example, ClickHouse, Redpanda, Redis, and Postgres are deployed as standalone services within the Kubernetes cluster.
+This setup is intended solely for demonstration and testing purposes.
+**For any real-life or production use case, you must provision and host these dependencies in a production-ready manner**
+—using managed services or properly secured, highly available deployments—rather than relying on the example manifests provided here.
+
+ **Security Notice:**
+
+The example manifests in this directory are for demonstration only.
+**TLS encryption and secure passwords are NOT enabled by default.**
+
+- **TLS:** All external services (Postgres, Redis, ClickHouse, Redpanda) are deployed without TLS.
+  - In production, you **must** enable TLS for all external services to protect data in transit.
+  - Update the `values.yaml` and external manifests to enable and configure TLS certificates.
+- **Passwords:** Default credentials (e.g., `postgres:postgres`, `redis:default`) are insecure and should **never** be used in production.
+  - Always set strong, unique passwords for all services.
+  - Store secrets securely (e.g., in Kubernetes Secrets or a secret manager).
+- **ClickHouse & Kafka:** The example disables authentication and encryption.
+  - Enable user authentication and configure secure connections for ClickHouse and Redpanda/Kafka.
+
+**Before using in production:**
+- Review and update all manifests to enforce strong authentication and TLS.
+- Never expose these example services to the public internet.
+- Refer to the official documentation for secure deployment practices.
+
+## Example Scenarios
+
+### Complete Events Stack
+Deploy all external dependencies and the events processing components:
+
+```bash
+# Deploy dependencies first
+kubectl apply -f external/postgres.yml -f external/redis.yml -f external/redpanda.yaml -f external/clickhouse.yaml
+
+# Install the events processing chart
+helm install lago-events-example --values values.yaml ../../
+```
+
+### Custom Configuration
+
+You can mix and match these examples or create your own:
+
+```bash
+# Use specific example values
+helm install lago-events-example --values values.yaml ../../
+
+# Or combine multiple configurations
+helm install lago-events-example --values values.yaml --values custom.yaml ../../
+```
+
+## Upgrading
+
+Once installed, you can upgrade with new configurations:
+
+```bash
+helm upgrade --values values.yaml --values custom.yaml lago ../../
+```
+
+## Notes
+
+- This is an **example repository** for demonstration purposes
+- For production deployments, refer to the official Lago documentation
+- Adjust resource limits and configurations based on your environment needs

--- a/charts/lago/examples/events-consumer/external/clickhouse.yaml
+++ b/charts/lago/examples/events-consumer/external/clickhouse.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+      - name: clickhouse
+        image: clickhouse/clickhouse-server:25.4-alpine
+        ports:
+        - containerPort: 9000
+        - containerPort: 8123
+        readinessProbe:
+          exec:
+            command:
+            - clickhouse-client
+            - --password
+            - default
+            - -q
+            - "SELECT 1"
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 5
+        volumeMounts:
+        - name: clickhouse-config
+          mountPath: /etc/clickhouse-server/config.d/config.xml
+          subPath: config.xml
+        - name: clickhouse-config
+          mountPath: /etc/clickhouse-server/users.d/users.xml
+          subPath: users.xml
+      volumes:
+      - name: clickhouse-config
+        configMap:
+          name: clickhouse-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+spec:
+  type: ClusterIP
+  selector:
+    app: clickhouse
+  ports:
+  - port: 9000
+    targetPort: 9000
+    name: tcp
+  - port: 8123
+    targetPort: 8123
+    name: http
+---
+apiVersion: v1
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: clickhouse-config
+data:
+  config.xml: |
+    <clickhouse replace="true">
+        <logger>
+            <level>debug</level>
+            <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+            <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+            <size>1000M</size>
+            <count>3</count>
+        </logger>
+        <display_name>clickhouse_dev</display_name>
+        <listen_host>0.0.0.0</listen_host>
+        <http_port>8123</http_port>
+        <tcp_port>9000</tcp_port>
+        <user_directories>
+            <users_xml>
+                <path>users.xml</path>
+            </users_xml>
+            <local_directory>
+                <path>/var/lib/clickhouse/access/</path>
+            </local_directory>
+        </user_directories>
+    </clickhouse>
+  users.xml: |
+    <?xml version="1.0"?>
+    <clickhouse replace="true">
+        <profiles>
+            <default>
+                <max_memory_usage>10000000000</max_memory_usage>
+                <use_uncompressed_cache>0</use_uncompressed_cache>
+                <load_balancing>in_order</load_balancing>
+                <log_queries>1</log_queries>
+            </default>
+        </profiles>
+        <users>
+            <default>
+                <access_management>1</access_management>
+                <profile>default</profile>
+                <password>default</password>
+                <networks>
+                    <ip>::/0</ip>
+                </networks>
+                <quota>default</quota>
+                <access_management>1</access_management>
+                <named_collection_control>1</named_collection_control>
+                <show_named_collections>1</show_named_collections>
+                <show_named_collections_secrets>1</show_named_collections_secrets>
+            </default>
+        </users>
+        <quotas>
+            <default>
+                <interval>
+                    <duration>3600</duration>
+                    <queries>0</queries>
+                    <errors>0</errors>
+                    <result_rows>0</result_rows>
+                    <read_rows>0</read_rows>
+                    <execution_time>0</execution_time>
+                </interval>
+            </default>
+        </quotas>
+    </clickhouse>

--- a/charts/lago/examples/events-consumer/external/postgres.yml
+++ b/charts/lago/examples/events-consumer/external/postgres.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_DB
+          value: lago
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+  - port: 5432
+    targetPort: 5432

--- a/charts/lago/examples/events-consumer/external/redis.yml
+++ b/charts/lago/examples/events-consumer/external/redis.yml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:alpine
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  type: ClusterIP
+  selector:
+    app: redis
+  ports:
+  - port: 6379
+    targetPort: 6379

--- a/charts/lago/examples/events-consumer/external/redpanda.yaml
+++ b/charts/lago/examples/events-consumer/external/redpanda.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redpanda
+  template:
+    metadata:
+      labels:
+        app: redpanda
+    spec:
+      containers:
+      - name: redpanda
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.9
+        args:
+        - redpanda start
+        - --smp 1
+        - --overprovisioned
+        - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+        - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+        ports:
+        - containerPort: 9092
+        readinessProbe:
+          httpGet:
+            path: /v1/status/ready
+            port: 9644
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+spec:
+  type: ClusterIP
+  selector:
+    app: redpanda
+  ports:
+  - port: 9092
+    targetPort: 9092

--- a/charts/lago/examples/events-consumer/values.yaml
+++ b/charts/lago/examples/events-consumer/values.yaml
@@ -1,0 +1,108 @@
+# apiUrl: "api.lago.dev"
+# frontUrl: "front.lago.dev"
+apiUrl: "https://example-api.staging.getlago.com"   # Example: https://api.mydomain.dev
+frontUrl: "https://example-app.staging.getlago.com"   # Example: https://app.mydomain.dev
+
+global:
+  # this is matching our standalone external services kubernetes config
+  # since we are in the same namespace, we can use the service name instead of
+  # postgres.default.svc.cluster.local and redis.default.svc.cluster.local
+  databaseUrl: postgres://postgres:postgres@postgres:5432/postgres
+  redisUrl: redis://redis:6379
+
+  ingress:
+    enabled: true
+    frontHostname: example-app.staging.getlago.com
+    apiHostname: example-api.staging.getlago.com
+    className: nginx
+
+  # this is the flag to enable clickhouse and event based features
+  clickhouse:
+    enabled: true
+    port: 8123
+    # same as postgres and redis, we can use the service name instead of
+    # clickhouse.default.svc.cluster.local
+    host: clickhouse
+    ssl: false
+    username: default
+    password: default
+    kafka:
+      tls: false
+      saslMechanisms: ""
+      securityProtocol: ""
+      # same as postgres and redis, we can use the service name instead of
+      # redpanda.default.svc.cluster.local
+      bootstrapServers:
+        - redpanda:9092
+
+api:
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+worker:
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+eventsConsumer:
+  resources:
+    requests:
+      memory: '128Mi'
+      cpu: "200m"
+
+eventsProcessor:
+  env: "development"
+  resources:
+    requests:
+      memory: '128Mi'
+      cpu: "200m"
+
+eventsWorker:
+  enabled: true
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+clockWorker:
+  enabled: true
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+pdf:
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+billingWorker:
+  enabled: true
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+pdfWorker:
+  enabled: true
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+webhookWorker:
+  enabled: true
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"
+
+paymentWorker:
+  enabled: true
+  resources:
+    requests:
+      memory: '512Mi'
+      cpu: "200m"

--- a/charts/lago/scripts/create-topics.sh
+++ b/charts/lago/scripts/create-topics.sh
@@ -1,0 +1,33 @@
+tmpf=$(mktemp)
+partition_count=3
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    url="https://github.com/redpanda-data/redpanda/releases/download/v25.2.5/rpk-linux-amd64.zip"
+    ;;
+  aarch64|arm64)
+    url="https://github.com/redpanda-data/redpanda/releases/download/v25.2.5/rpk-linux-arm64.zip"
+    ;;
+  *)
+    echo "Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+wget -qO- "$url" > "$tmpf"
+unzip -o "$tmpf"
+
+# due to https://github.com/redpanda-data/redpanda/issues/6651
+# we need to create the topics only if they don't exist
+# this script gets the list of topics from the arguments
+# and creates them if they don't exist, creation is not invoked if the topics already exist
+./rpk topic list | awk -v expected="$topics" '
+BEGIN {
+    n = split(expected, exp_array, " ")
+    for (i = 1; i <= n; i++)  expected_topics[exp_array[i]] = 1
+} NR > 1 {
+    actual_topics[$1] = 1
+} END {
+    for (topic in expected_topics) {
+        if (!(topic in actual_topics)) printf "%s ", topic
+    }
+}' | xargs -r ./rpk topic create --partitions $partition_count

--- a/charts/lago/templates/_helpers.tpl
+++ b/charts/lago/templates/_helpers.tpl
@@ -22,10 +22,66 @@
 {{- end }}
 {{- end}}
 
-{{- define "migrateJobName" }}
-{{- if .Values.job.migrate.nameOverride -}}
-{{ .Values.job.migrate.nameOverride }}
-{{- else -}}
-{{ printf "%s-migrate-%s" .Release.Name (.Values | toYaml | cat .Chart.Version | sha256sum | trunc 8) }}
+{{- define "kafkaEnvs" }}
+{{- $kafka := .Values.global.clickhouse.kafka -}}
+- name: LAGO_KAFKA_BOOTSTRAP_SERVERS
+  value: {{ required "If clickhouse is enabled, you must provide a list of Kafka servers"
+    $kafka.bootstrapServers | join "," }}
+- name: LAGO_KAFKA_CONSUMER_GROUP
+  value: {{ $kafka.consumerGroup | quote }}
+- name: LAGO_KAFKA_ENRICHED_EVENTS_EXPANDED_TOPIC
+  value: {{ $kafka.topics.eventsEnrichedExpanded | quote }}
+- name: LAGO_KAFKA_ENRICHED_EVENTS_TOPIC
+  value: {{ $kafka.topics.eventsEnriched | quote }}
+- name: LAGO_KAFKA_EVENTS_CHARGED_IN_ADVANCE_TOPIC
+  value: {{ $kafka.topics.eventsChargedInAdvance | quote }}
+- name: LAGO_KAFKA_EVENTS_DEAD_LETTER_TOPIC
+  value: {{ $kafka.topics.eventsDeadLetter | quote }}
+- name: LAGO_KAFKA_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "secret-path" . }}
+      key: kafkaPassword
+      optional: true
+- name: LAGO_KAFKA_RAW_EVENTS_TOPIC
+  value: {{ $kafka.topics.eventsRaw | quote }}
+- name: LAGO_KAFKA_SCRAM_ALGORITHM
+  value: {{ $kafka.saslMechanisms | quote }}
+- name: LAGO_KAFKA_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "secret-path" . }}
+      key: kafkaUsername
+      optional: true
+- name: LAGO_KAFKA_TLS
+  value: {{ $kafka.tls | quote }}
 {{- end }}
-{{- end}}
+
+{{- define "clickhouseEnvs" }}
+- name: LAGO_KAFKA_ACTIVITY_LOGS_TOPIC
+  value: {{ .Values.global.clickhouse.kafka.topics.activityLogs | quote }}
+- name: LAGO_KAFKA_API_LOGS_TOPIC
+  value: {{ .Values.global.clickhouse.kafka.topics.apiLogs | quote }}
+- name: LAGO_CLICKHOUSE_PORT
+  value: "{{ .Values.global.clickhouse.port }}"
+- name: LAGO_CLICKHOUSE_HOST
+  value: {{ .Values.global.clickhouse.host }}
+- name: LAGO_CLICKHOUSE_SSL
+  value: "{{ .Values.global.clickhouse.ssl }}"
+- name: LAGO_CLICKHOUSE_ENABLED
+  value: "true"
+- name: LAGO_CLICKHOUSE_DATABASE
+  value: "default"
+- name: LAGO_CLICKHOUSE_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "secret-path" . }}
+      key: clickhouseUsername
+      optional: true
+- name: LAGO_CLICKHOUSE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "secret-path" . }}
+      key: clickhousePassword
+      optional: true
+{{- end }}

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -237,6 +237,10 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
+            {{ if .Values.global.clickhouse.enabled }}
+            {{- include "kafkaEnvs" . | nindent 12 }}
+            {{- include "clickhouseEnvs" . | nindent 12 }}
+            {{ end }}
           image: getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-api
           ports:

--- a/charts/lago/templates/create-topic-job.yaml
+++ b/charts/lago/templates/create-topic-job.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.global.clickhouse.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-create-kafka-topics
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- range $key, $value := .Values.job.topics.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.job.topics.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: create-topics
+          image: alpine:3.20
+          command: [sh]
+          args:
+            - -c
+            - |
+              topics="{{ values .Values.global.clickhouse.kafka.topics | join " " }}"
+              echo "Creating Kafka topics: $topics"
+              {{- .Files.Get "scripts/create-topics.sh" | nindent 14 }}
+          env:
+            - name: RPK_BROKERS
+              value: {{ .Values.global.clickhouse.kafka.bootstrapServers | join "," }}
+            {{- with .Values.job.topics.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.job.topics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/lago/templates/events-consumer-worker-deployment.yaml
+++ b/charts/lago/templates/events-consumer-worker-deployment.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.global.clickhouse.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.lago.service: {{ .Release.Name }}-events-consumer-worker
+  name: {{ .Release.Name }}-events-consumer-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.lago.service: {{ .Release.Name }}-events-consumer-worker
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        io.lago.service: {{ .Release.Name }}-events-consumer-worker
+        {{- range $key, $value := .Values.eventsConsumer.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.eventsConsumer.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- with .Values.eventsConsumer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventsConsumer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventsConsumer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Release.Name }}-events-consumer-worker
+          image: getlago/api:v{{ .Values.version }}
+          command: ["./scripts/start.events.consumer.sh"]
+        {{- with .Values.eventsConsumer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+          env:
+            - name: DATABASE_POOL
+              value: {{ quote .Values.eventsConsumer.databasePool }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: databaseUrl
+            - name: ENCRYPTION_DETERMINISTIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "encryption-secret-path" . }}
+                  key: encryptionDeterministicKey
+            - name: ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "encryption-secret-path" . }}
+                  key: encryptionKeyDerivationSalt
+            - name: ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "encryption-secret-path" . }}
+                  key: encryptionPrimaryKey
+            {{- include "kafkaEnvs" . | nindent 12 }}
+            {{ if .Values.global.license }}
+            - name: LAGO_LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: license
+            {{ end }}
+            - name: LAGO_LOG_LEVEL
+              value: {{ .Values.eventsConsumer.rails.logLevel | quote }}
+            - name: LAGO_REDIS_CACHE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: redisCacheUrl
+            - name: LAGO_REDIS_STORE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: redisUrl
+            - name: LAGO_RSA_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: rsaPrivateKey
+            - name: RAILS_ENV
+              value: {{ .Values.eventsConsumer.rails.env }}
+            - name: RAILS_LOG_TO_STDOUT
+              value: {{ .Values.eventsConsumer.rails.logStdout | quote }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: redisUrl
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: secretKeyBase
+            {{- with .Values.eventsConsumer.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+      restartPolicy: Always
+      serviceAccountName: {{ .Values.global.serviceAccountName | default (printf "%s-serviceaccount" .Release.Name) }}
+{{- end }}

--- a/charts/lago/templates/events-processor-worker-deployment.yaml
+++ b/charts/lago/templates/events-processor-worker-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.global.clickhouse.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.lago.service: {{ .Release.Name }}-events-processor-worker
+  name: {{ .Release.Name }}-events-processor-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.lago.service: {{ .Release.Name }}-events-processor-worker
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        io.lago.service: {{ .Release.Name }}-events-processor-worker
+        {{- range $key, $value := .Values.eventsProcessor.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.eventsProcessor.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- with .Values.eventsProcessor.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventsProcessor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventsProcessor.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Release.Name }}-events-processor-worker
+          image: getlago/lago-events-processor:v{{ .Values.version }}
+          command: ["./event_processors"]
+        {{- with .Values.eventsProcessor.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+          env:
+            {{- include "kafkaEnvs" . | nindent 12 }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: databaseUrl
+            - name: ENV
+              value: {{ .Values.eventsProcessor.env }}
+            - name: LAGO_EVENTS_PROCESSOR_DATABASE_MAX_CONNECTIONS
+              value: {{ .Values.eventsProcessor.databasePool | quote }}
+            - name: LAGO_REDIS_CACHE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: redisCacheUrl
+            - name: LAGO_REDIS_STORE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secret-path" . }}
+                  key: redisUrl
+            {{- with .Values.eventsProcessor.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+      restartPolicy: Always
+      serviceAccountName: {{ .Values.global.serviceAccountName | default (printf "%s-serviceaccount" .Release.Name) }}
+
+{{- end }}

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -1,9 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ include "migrateJobName" . }}"
-  labels:
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: {{ .Release.Name }}-migrate-db
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-1"
@@ -11,11 +9,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{ include "migrateJobName" . }}"
       labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         {{- range $key, $value := .Values.job.migrate.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
@@ -74,8 +68,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "encryption-secret-path" . }}
                   key: encryptionPrimaryKey
+            {{ if .Values.global.clickhouse.enabled }}
+            {{- include "kafkaEnvs" . | nindent 12 }}
+            {{- include "clickhouseEnvs" . | nindent 12 }}
+            - name: LAGO_CLICKHOUSE_MIGRATIONS_ENABLED
+              value: "true"
+            - name: LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP
+              value: clickhouse
+            {{ end }}
+            {{- with .Values.job.migrate.extraEnv }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           {{- with .Values.job.migrate.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      serviceAccountName: {{ .Values.global.serviceAccountName | default (printf "%s-serviceaccount" .Release.Name) }}

--- a/charts/lago/templates/secrets.yaml
+++ b/charts/lago/templates/secrets.yaml
@@ -82,3 +82,12 @@ data:
   googleAuthClientSecret: {{ .Values.global.googleAuth.clientSecret | b64enc }}
   {{ end }}
   {{- end }}
+
+  {{- if not .Values.global.existingSecret }}
+  {{ if .Values.global.clickhouse.enabled }}
+  kafkaUsername: {{ default "" .Values.global.clickhouse.kafka.username | b64enc }}
+  kafkaPassword: {{ default "" .Values.global.clickhouse.kafka.password | b64enc }}
+  clickhouseUsername: {{ default "" .Values.global.clickhouse.username | b64enc }}
+  clickhousePassword: {{ default "" .Values.global.clickhouse.password | b64enc }}
+  {{ end }}
+  {{- end }}

--- a/charts/lago/tests/clickhouse_test.yaml
+++ b/charts/lago/tests/clickhouse_test.yaml
@@ -1,0 +1,38 @@
+suite: Test clickhouse activation and default values
+templates:
+  - templates/events-consumer-worker-deployment.yaml
+  - templates/events-processor-worker-deployment.yaml
+
+tests:
+  - it: should not deploy if clickhouse is disabled
+    set:
+      global.clickhouse.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should deploy if clickhouse is enabled
+    set:
+      releaseName: lago
+      global.clickhouse.enabled: true
+      global.clickhouse.kafka.bootstrapServers:
+        - "kafka-server:9092"
+    asserts:
+      - containsDocument:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: RELEASE-NAME-events-consumer-worker
+      - containsDocument:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: RELEASE-NAME-events-processor-worker
+
+  - it: should error if kafka bootstrap servers are not provided
+    template: templates/events-processor-worker-deployment.yaml
+    set:
+      global.clickhouse.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "If clickhouse is enabled, you must provide a list of Kafka servers"

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -1,4 +1,8 @@
-version: 1.32.4
+version: 1.33.4
+
+# EXAMPLE CONFIGURATION - Lago Events Processing Components
+# This is a standalone example demonstrating Lago's events processing capabilities
+# For production deployments, refer to the official Lago documentation
 
 # Required: Set the URLs for your API and Frontend services
 # Replace these placeholders with the actual domain names.
@@ -71,7 +75,7 @@ global:
     enabled: false
     frontHostname:
     apiHostname:
-    className:
+    className: nginx
     annotations: {}
 
   networkPolicy:
@@ -84,6 +88,35 @@ global:
     imageRepository: rancher/kubectl
     # If imageTag is not supplied it will be inferred using the version of the cluster that Lago is deployed on.
     # imageTag: 1.29.0
+
+  clickhouse:
+    enabled: false
+    port: 9000
+    host: clickhouse
+    ssl: true
+    # username and password are not required here if using existingSecret
+    username: ""
+    password: ""
+    kafka:
+      # username and password are not required here if using existingSecret
+      # username:
+      # password:
+      tls: true
+      saslMechanisms: SCRAM-SHA-512
+      securityProtocol: SASL_SSL
+      consumerGroup: events_consumer
+      # you must provide a list of Kafka servers if clickhouse is enabled
+      # bootstrapServers:
+      #   - "kafka-server:9092"
+      topics:
+        eventsChargedInAdvance: events_charged_in_advance
+        eventsDeadLetter: events_dead_letter
+        eventsEnriched: events_enriched
+        eventsEnrichedExpanded: events_enriched_expanded
+        eventsRaw: events_raw
+        activityLogs: activity_logs
+        apiLogs: api_logs
+
 
 encryption:
   # The following fields are required:
@@ -176,6 +209,38 @@ worker:
     periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
+
+
+eventsConsumer:
+  databasePool: 10
+  rails:
+    env: "production"
+    logStdout: true
+    logLevel: error
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: "1100m"
+  podAnnotations: {}
+  podLabels: {}
+  extraEnv: {}
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
+
+eventsProcessor:
+  databasePool: 10
+  env: "production"
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: "1100m"
+  podAnnotations: {}
+  podLabels: {}
+  extraEnv: {}
   tolerations: []
   nodeSelector: {}
   affinity: {}
@@ -410,7 +475,14 @@ job:
     podAnnotations: {}
     podLabels: {}
     resources: {}
+    extraEnv: {}
     loadSchema: false
+  topics:
+    resources: {}
+    extraEnv: {}
+    podAnnotations: {}
+    podLabels: {}
+
 
 minio:
   enabled: false


### PR DESCRIPTION
If clickhouse is enabled we must deploy additional resources. Namely the events processor and the events consumer. Also, those will use a Kafka instance and its endpoint must be provided.