### PR TITLE
fix: add conditional checks to chart testing workflow steps

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -37,16 +37,19 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.12.0
 
       - name: Create lago namespace
+        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl create namespace lago
-      
+
       - name: Install Postgres
+        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl apply -f ./charts/lago/ci/postgres.yml
 
       - name: Install Redis
+        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl apply -f ./charts/lago/ci/redis.yml
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
Add 'if: steps.list-changed.outputs.changed == 'true'' condition to:
  - Create kind cluster step
  - Create lago namespace step
  - Install Postgres step
  - Install Redis step 

This prevents unnecessary resource creation and failure when no charts have changed