### PR TITLE
refactor: Remove 'lago' namespace from Helm chart configurations

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config ct.yaml --namespace lago
+        run: ct install --config ct.yaml --namespace default

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -35,7 +35,6 @@ tasks:
         msg: "❌ chart-testing not found (see: https://github.com/helm/chart-testing)"
     cmds:
       - task: kind:up
-      - kubectl create namespace lago
       - kubectl apply -f charts/lago/ci/postgres.yml
       - kubectl apply -f charts/lago/ci/redis.yml
-      - ct install --config ct.yaml --namespace lago
+      - ct install --config ct.yaml --namespace default

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.26.1
+version: 1.26.2
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/ci/postgres.yml
+++ b/charts/lago/ci/postgres.yml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres
-  namespace: lago
 spec:
   replicas: 1
   selector:
@@ -30,7 +29,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
-  namespace: lago
 spec:
   type: ClusterIP
   selector:

--- a/charts/lago/ci/redis.yml
+++ b/charts/lago/ci/redis.yml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
-  namespace: lago
 spec:
   replicas: 1
   selector:
@@ -23,7 +22,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: lago
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Eliminate the 'lago' namespace specification from the Postgres and Redis chart files, as well as from the Taskfile and GitHub Actions workflow. This change simplifies multiple parts of the github action and testing workflow