### PR TITLE
refactor: use helm hooks to handle migration

### DIFF
--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.26.0
+version: 1.26.1
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -45,13 +45,6 @@ spec:
             - --for=condition=ready
             - --timeout=180s
         {{ end }}
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.api.sh"]
           env:

--- a/charts/lago/templates/billing-worker-deployment.yaml
+++ b/charts/lago/templates/billing-worker-deployment.yaml
@@ -36,14 +36,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.billing.worker.sh"]
           env:

--- a/charts/lago/templates/clock-deployment.yaml
+++ b/charts/lago/templates/clock-deployment.yaml
@@ -35,14 +35,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.clock.sh"]
           env:

--- a/charts/lago/templates/clock-worker-deployment.yaml
+++ b/charts/lago/templates/clock-worker-deployment.yaml
@@ -36,14 +36,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.clock.worker.sh"]
           env:

--- a/charts/lago/templates/events-worker-deployment.yaml
+++ b/charts/lago/templates/events-worker-deployment.yaml
@@ -35,14 +35,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.events.worker.sh"]
           env:

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -4,6 +4,10 @@ metadata:
   name: "{{ include "migrateJobName" . }}"
   labels:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/charts/lago/templates/payment-worker-deployment.yaml
+++ b/charts/lago/templates/payment-worker-deployment.yaml
@@ -36,14 +36,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.payments.worker.sh"]
           env:

--- a/charts/lago/templates/pdf-worker-deployment.yaml
+++ b/charts/lago/templates/pdf-worker-deployment.yaml
@@ -36,14 +36,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.pdfs.worker.sh"]
           env:

--- a/charts/lago/templates/secrets.yaml
+++ b/charts/lago/templates/secrets.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-secrets
   annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-2"
     helm.sh/resource-policy: keep
 type: Opaque
 data:

--- a/charts/lago/templates/serviceaccount.yml
+++ b/charts/lago/templates/serviceaccount.yml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-serviceaccount
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-2"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +26,6 @@ rules:
     {{ if .Values.minio.enabled }}
     - {{ .Release.Name }}-minio-0
     {{ end}}
-    - {{ include "migrateJobName" . }}
   verbs:
     - get
     - list

--- a/charts/lago/templates/webhook-worker-deployment.yaml
+++ b/charts/lago/templates/webhook-worker-deployment.yaml
@@ -36,14 +36,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.webhook.worker.sh"]
           env:

--- a/charts/lago/templates/worker-deployment.yaml
+++ b/charts/lago/templates/worker-deployment.yaml
@@ -35,14 +35,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-migrations
-          image: "{{ .Values.global.kubectl.imageRegistry }}/{{ .Values.global.kubectl.imageRepository }}:{{ include "kubectlVersion" . }}"
-          args:
-            - wait
-            - job/{{ include "migrateJobName" . }}
-            - --for=condition=complete
-            - --timeout=180s
       containers:
         - args: ["./scripts/start.worker.sh"]
           env:


### PR DESCRIPTION
Eliminate the 'wait-for-migrations' initContainers from various worker and deployment templates since we are now relying on the hook.