### PR TITLE
ci(chart-release): add manual trigger support

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Add workflow_dispatch trigger to allow running the chart release workflow manually from the GitHub Actions UI, in addition to the existing push-to-main trigger.