### PR TITLE
chore(ci): force workflow re-index for workflow_dispatch

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,5 +1,6 @@
 name: Release charts
 
+# yaml-anchor: force workflow re-index
 on:
   push:
     branches:

--- a/.github/workflows/chart-unit-testing.yml
+++ b/.github/workflows/chart-unit-testing.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on:
+  push:
+  pull_request:
 
 name: Unit tests Charts
 
@@ -11,7 +13,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Helm and run tests
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Build Helm dependencies
+        run: |
+          for chart in charts/*/; do
+            if [ -f "$chart/Chart.yaml" ]; then
+              helm dependency build "$chart"
+            fi
+          done
+
+      - name: Run unit tests
         uses: d3adb5/helm-unittest-action@v2
         with:
           helm-version: v3.18.4


### PR DESCRIPTION
## Summary
- GitHub's workflow index is stale and not recognizing the `workflow_dispatch` trigger added in #195
- Adds a no-op comment to force re-indexing of the workflow definition so manual triggers work again