### PR TITLE
docs(lago): add SealedSecret example with external secret management

### DIFF
--- a/charts/lago/examples/sealed_secret.yaml
+++ b/charts/lago/examples/sealed_secret.yaml
@@ -1,0 +1,84 @@
+# Example: Using a SealedSecret instead of the chart-managed Secret
+#
+# This example shows how to:
+#   1. Disable the default secret creation (config.secret.create: false)
+#   2. Point the chart to an externally managed secret (global.config.secret)
+#   3. Deploy a SealedSecret via extraObjects that produces the expected Secret
+#
+# Prerequisites:
+#   - Sealed Secrets controller installed in your cluster
+#     (https://github.com/bitnami-labs/sealed-secrets)
+#   - Use `kubeseal` to encrypt your secret values before pasting them here
+#
+# To generate encrypted values:
+#   echo -n "your-value" | kubeseal --raw --namespace default --name lago-sealed-secret --from-file=/dev/stdin
+#
+# Usage:
+#   helm install lago lago/lago -f sealed_secret.yaml
+
+global:
+  urls:
+    api: "https://lago-api.example.com"
+    front: "https://lago.example.com"
+
+  # Non-sensitive config still goes here
+  redis:
+    uri: "redis://lago-redis.default.svc.cluster.local:6379"
+  redisCache:
+    uri: "redis://lago-redis.default.svc.cluster.local:6379"
+  redisStore:
+    uri: "redis://lago-redis.default.svc.cluster.local:6379"
+
+  config:
+    # Point all chart components to the Secret produced by the SealedSecret
+    secret: "lago-sealed-secret"
+
+# Disable the chart-managed secret — the SealedSecret will create it instead
+config:
+  secret:
+    create: false
+
+api:
+  ingress:
+    enabled: true
+    hosts:
+      - host: lago-api.example.com
+    tls:
+      - secretName: lago-api-example-tls
+        hosts:
+          - lago-api.example.com
+
+front:
+  ingress:
+    enabled: true
+    hosts:
+      - host: lago.example.com
+    tls:
+      - secretName: lago-example-tls
+        hosts:
+          - lago.example.com
+
+migrate:
+  enabled: true
+
+# Deploy the SealedSecret as an extra object
+extraObjects:
+  - apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    metadata:
+      name: lago-sealed-secret
+    spec:
+      encryptedData:
+        # Required keys — replace these with your actual kubeseal-encrypted values
+        database.uri: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+        encryption.key: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+        encryption.salt: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+        signing.hmac: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+        signing.rsa: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+        # Optional keys — uncomment and encrypt as needed
+        # redis.password: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+        # lago.license: "AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq..."
+      template:
+        metadata:
+          name: lago-sealed-secret
+        type: Opaque


### PR DESCRIPTION
## Summary
- Adds `charts/lago/examples/sealed_secret.yaml` showing how to use a Bitnami SealedSecret via `extraObjects`
- Demonstrates disabling chart-managed secret creation (`config.secret.create: false`) and pointing components to an external secret (`global.config.secret`)
- Documents the `kubeseal` workflow for encrypting secret values

Closes #199