### PR TITLE
Include an image-registry path that defaults to docker.io

### DIFF
--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.27.1
+version: 1.27.2
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -241,7 +241,7 @@ spec:
             {{- include "kafkaEnvs" . | nindent 12 }}
             {{- include "clickhouseEnvs" . | nindent 12 }}
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-api
           ports:
             - name: http

--- a/charts/lago/templates/billing-worker-deployment.yaml
+++ b/charts/lago/templates/billing-worker-deployment.yaml
@@ -208,7 +208,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-billing-worker
           {{- if .Values.billingWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/clock-deployment.yaml
+++ b/charts/lago/templates/clock-deployment.yaml
@@ -105,7 +105,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-clock
           {{- with .Values.clock.resources }}
           resources:

--- a/charts/lago/templates/clock-worker-deployment.yaml
+++ b/charts/lago/templates/clock-worker-deployment.yaml
@@ -190,7 +190,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-clock-worker
           {{- if .Values.clockWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/create-topic-job.yaml
+++ b/charts/lago/templates/create-topic-job.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: create-topics
-          image: alpine:3.20
+          image: {{ .Values.global.image.registry }}/library/alpine:3.20
           command: [sh]
           args:
             - -c

--- a/charts/lago/templates/events-consumer-worker-deployment.yaml
+++ b/charts/lago/templates/events-consumer-worker-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-events-consumer-worker
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           command: ["./scripts/start.events.consumer.sh"]
         {{- with .Values.eventsConsumer.resources }}
           resources:

--- a/charts/lago/templates/events-processor-worker-deployment.yaml
+++ b/charts/lago/templates/events-processor-worker-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-events-processor-worker
-          image: getlago/lago-events-processor:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/lago-events-processor:v{{ .Values.version }}
           command: ["./event_processors"]
         {{- with .Values.eventsProcessor.resources }}
           resources:

--- a/charts/lago/templates/events-worker-deployment.yaml
+++ b/charts/lago/templates/events-worker-deployment.yaml
@@ -111,7 +111,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-events-worker
           {{- with .Values.eventsWorker.resources }}
           resources:

--- a/charts/lago/templates/front-deployment.yaml
+++ b/charts/lago/templates/front-deployment.yaml
@@ -53,7 +53,7 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-          image: getlago/front:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/front:v{{ .Values.version }}
           name: {{ .Release.Name }}-front
           ports:
             - containerPort: 80

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -21,7 +21,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: lago-migrate
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           {{ if .Values.job.migrate.loadSchema }}
           command: ["bin/rails"]
           args:

--- a/charts/lago/templates/payment-worker-deployment.yaml
+++ b/charts/lago/templates/payment-worker-deployment.yaml
@@ -208,7 +208,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-payment-worker
           {{- if .Values.paymentWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/pdf-deployment.yaml
+++ b/charts/lago/templates/pdf-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: getlago/lago-gotenberg:8.15
+        - image: {{ .Values.global.image.registry }}/getlago/lago-gotenberg:8.15
           name: {{ .Release.Name }}-pdf
           ports:
             - containerPort: 3000

--- a/charts/lago/templates/pdf-worker-deployment.yaml
+++ b/charts/lago/templates/pdf-worker-deployment.yaml
@@ -208,7 +208,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-pdf-worker
           {{- if .Values.pdfWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/webhook-worker-deployment.yaml
+++ b/charts/lago/templates/webhook-worker-deployment.yaml
@@ -114,7 +114,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-webhook-worker
           {{- with .Values.webhookWorker.resources }}
           resources:

--- a/charts/lago/templates/worker-deployment.yaml
+++ b/charts/lago/templates/worker-deployment.yaml
@@ -207,7 +207,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-worker
           {{- if .Values.worker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -83,6 +83,13 @@ global:
     egress: []
     ingress: []
 
+  # Default registry used for all chart-managed images (getlago/api,
+  # getlago/front, getlago/lago-events-processor, getlago/lago-gotenberg,
+  # alpine). Override to point at a private registry or mirror. Must be
+  # reachable from cluster nodes.
+  image:
+    registry: docker.io
+
   kubectl:
     imageRegistry: docker.io
     imageRepository: rancher/kubectl


### PR DESCRIPTION
Fixes #203 Deployment fails when short name mode is enforcing.