### PR TITLE
feat(lago-data-rev-rec): add chart for the rev_rec Beam pipeline

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -13,6 +13,7 @@ CHARTS=(
   lago-data-api
   lago-data-worker
   lago-data-forecasted-usage
+  lago-data-rev-rec
   lago-mcp-server
   lago-pdf
   lago-data

--- a/charts/lago-data-rev-rec/Chart.yaml
+++ b/charts/lago-data-rev-rec/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lago-data-rev-rec
+description: Apache Beam revenue-recognition pipeline on Flink
+type: application
+version: 0.5.1
+appVersion: "0.5.1"

--- a/charts/lago-data-rev-rec/templates/_helpers.tpl
+++ b/charts/lago-data-rev-rec/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "lago-data-rev-rec.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "lago-data-rev-rec.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+The Flink Kubernetes Operator auto-creates a ClusterIP Service named
+<flinkdeployment-name>-rest exposing the JobManager REST API on port 8081.
+*/}}
+{{- define "lago-data-rev-rec.flinkRest" -}}
+{{- printf "%s-rest" (include "lago-data-rev-rec.fullname" .) -}}
+{{- end -}}
+
+{{- define "lago-data-rev-rec.submitterImage" -}}
+{{- $repo := required "submitter.image.repository is required" .Values.submitter.image.repository -}}
+{{- $tag  := required "submitter.image.tag is required"        .Values.submitter.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{- define "lago-data-rev-rec.flinkImage" -}}
+{{- $repo := required "image.repository is required" .Values.image.repository -}}
+{{- $tag  := required "image.tag is required"        .Values.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
+Name of the ServiceAccount the FlinkDeployment and submitter Job run under.
+If serviceAccount.create is true, defaults to the chart fullname; otherwise the
+user-supplied serviceAccount.name is required (the lago-data Pulumi component
+sets create=false and provides the name).
+*/}}
+{{- define "lago-data-rev-rec.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "lago-data-rev-rec.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lago-data-rev-rec/templates/deployment.yaml
+++ b/charts/lago-data-rev-rec/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: {{ include "lago-data-rev-rec.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-rev-rec.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  image: {{ include "lago-data-rev-rec.flinkImage" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  flinkVersion: {{ .Values.flinkVersion }}
+  serviceAccount: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+  # The K8s operator manages kubernetes.cluster-id internally — setting it here
+  # is rejected by the admission webhook.
+  flinkConfiguration:
+    high-availability.type: kubernetes
+    high-availability.storageDir: {{ required "config.highAvailability.storageDir is required" .Values.config.highAvailability.storageDir | quote }}
+    state.backend.type: {{ .Values.config.checkpointing.stateBackend | default "rocksdb" | quote }}
+    state.backend.incremental: {{ .Values.config.checkpointing.incremental | default "true" | toString | quote }}
+    state.checkpoints.dir: {{ required "config.checkpointing.storageDir is required" .Values.config.checkpointing.storageDir | quote }}
+    state.savepoints.dir: {{ required "config.checkpointing.savepointDir is required" .Values.config.checkpointing.savepointDir | quote }}
+    {{- range $k, $v := .Values.config.extraConfig }}
+    {{ $k }}: {{ $v | toString | quote }}
+    {{- end }}
+  jobManager:
+    replicas: {{ .Values.jobManager.replicas }}
+    resource:
+      {{- toYaml .Values.jobManager.resource | nindent 6 }}
+  taskManager:
+    replicas: {{ .Values.taskManager.replicas }}
+    resource:
+      {{- toYaml .Values.taskManager.resource | nindent 6 }}
+    podTemplate:
+      spec:
+        containers:
+          - name: flink-main-container
+            # operator injects flink config; nothing else to set here
+          - name: beam-py-harness
+            # Python SDK harness — Flink TaskManagers dial localhost:<port> for
+            # python user code execution (rev_rec DoFns) when the pipeline runs
+            # with --environment_type=EXTERNAL.
+            image: {{ include "lago-data-rev-rec.submitterImage" . }}
+            imagePullPolicy: {{ .Values.submitter.image.pullPolicy }}
+            command:
+              - python
+              - -m
+              - apache_beam.runners.worker.worker_pool_main
+              - --service_port={{ .Values.harnessSidecar.port }}
+            ports:
+              - containerPort: {{ .Values.harnessSidecar.port }}
+                name: py-harness
+            resources:
+              {{- toYaml .Values.taskManager.sidecarResources | nindent 14 }}

--- a/charts/lago-data-rev-rec/templates/rbac.yaml
+++ b/charts/lago-data-rev-rec/templates/rbac.yaml
@@ -1,0 +1,37 @@
+{{- /*
+RBAC for Flink Kubernetes HA: the JobManager uses ConfigMaps for leader
+election + JobGraph metadata, lists Pods to discover peers, and patches its
+own Deployment during shutdown. Binds to the chart-managed ServiceAccount
+(or to a Pulumi-owned SA when serviceAccount.create is false, e.g. for EKS
+Pod Identity wiring).
+*/ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-rev-rec.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: [pods, configmaps]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [apps]
+    resources: [deployments, deployments/finalizers]
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-rev-rec.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/lago-data-rev-rec/templates/serviceaccount.yaml
+++ b/charts/lago-data-rev-rec/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-rev-rec.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/lago-data-rev-rec/templates/submitter-job.yaml
+++ b/charts/lago-data-rev-rec/templates/submitter-job.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lago-data-rev-rec.fullname" . }}-submitter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-rev-rec.labels" . | nindent 4 }}
+  {{- with .Values.submitter.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.submitter.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.submitter.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "lago-data-rev-rec.labels" . | nindent 8 }}
+        app.kubernetes.io/component: submitter
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+      containers:
+        - name: submitter
+          image: {{ include "lago-data-rev-rec.submitterImage" . }}
+          imagePullPolicy: {{ .Values.submitter.image.pullPolicy }}
+          command:
+            - python
+            - -m
+            - run
+          args:
+            - --runner=FlinkRunner
+            - --flink_master={{ include "lago-data-rev-rec.flinkRest" . }}:8081
+            - --flink_version=1.20
+            - --environment_type=EXTERNAL
+            - --environment_config=localhost:{{ .Values.harnessSidecar.port }}
+            - --streaming
+            - --save_main_session
+            - --checkpointing_interval={{ .Values.submitter.checkpointingIntervalMs }}
+            {{- range .Values.submitter.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          env:
+            - name: JAVA_TOOL_OPTIONS
+              value: {{ .Values.submitter.javaToolOptions | quote }}
+            # Path baked into the submitter image; rev_rec reads it to launch
+            # the Beam Java IO expansion service in-process.
+            - name: KAFKA_EXPANSION_SERVICE_JAR
+              value: /opt/apache/beam/jars/beam-sdks-java-io-expansion-service.jar
+            {{- with .Values.submitter.triggerTime }}
+            - name: TRIGGER_TIME
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.submitter.kafka.consumerGroup }}
+            - name: CONSUMER_GROUP
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.submitter.kafka.autoOffsetReset }}
+            - name: KAFKA_AUTO_OFFSET_RESET
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.submitter.logging.level }}
+            - name: LOG_LEVEL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.submitter.logging.frameworkLevel }}
+            - name: LOG_FRAMEWORK_LEVEL
+              value: {{ . | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ required "submitter.secrets.postgres is required" .Values.submitter.secrets.postgres }}
+            - secretRef:
+                name: {{ required "submitter.secrets.kafka is required"    .Values.submitter.secrets.kafka }}
+          resources:
+            {{- toYaml .Values.submitter.resources | nindent 12 }}

--- a/charts/lago-data-rev-rec/values.yaml
+++ b/charts/lago-data-rev-rec/values.yaml
@@ -1,0 +1,136 @@
+# Default values for the lago-data-rev-rec chart.
+#
+# Namespace comes from the helm release (`--namespace`, or Argo Application
+# `destination.namespace`) and is read via `.Release.Namespace` in the
+# templates — there is no namespace value to override here.
+#
+# The primary resource is the FlinkDeployment — its image/annotations/replicas/
+# etc. live at the root. Subordinate resources (submitter Job, RBAC) live under
+# their own keys.
+
+# Flink runtime image (Java side, with the Beam SDK boot binary + S3 plugin
+# baked in). The submitter / harness Python image lives under `submitter.image`.
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Annotations applied to the FlinkDeployment resource.
+annotations: {}
+
+# Additional labels merged into the FlinkDeployment resource labels.
+labels: {}
+
+flinkVersion: v1_20
+
+jobManager:
+  replicas: 2
+  resource:
+    cpu: 1
+    memory: 2048m
+
+taskManager:
+  replicas: 2
+  resource:
+    cpu: 1
+    memory: 2048m
+  # Resources for the beam-py-harness sidecar that runs the Python SDK
+  # worker pool. Sized for the pickled rev_rec DoFn graph; bump if you
+  # increase pipeline parallelism or stream count.
+  sidecarResources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+
+harnessSidecar:
+  port: 50000
+
+# Flink configuration map. Chart-managed defaults (HA + checkpointing) are
+# emitted first, then `config.extraConfig` — when both set the same key, YAML
+# last-wins gives extraConfig precedence.
+config:
+  highAvailability:
+    # Required. K8s-API HA via ConfigMaps for leader election + JobGraph storage,
+    # plus the storageDir on S3 for JobGraph blobs. Set via Pulumi valuesObject
+    # from the data-services stack output (do not hardcode).
+    storageDir: ""
+  checkpointing:
+    # Required. Set via Pulumi valuesObject (data-services checkpoint bucket).
+    storageDir: ""
+    # Required. Set via Pulumi valuesObject.
+    savepointDir: ""
+    stateBackend: rocksdb
+    incremental: "true"
+  # Additional Flink config keys merged on top of the chart-rendered ones.
+  extraConfig:
+    taskmanager.numberOfTaskSlots: "2"
+    classloader.resolve-order: parent-first
+    env.java.opts.jobmanager: "-Djava.security.egd=file:/dev/./urandom"
+    env.java.opts.taskmanager: "-Djava.security.egd=file:/dev/./urandom"
+
+# ServiceAccount used by the FlinkDeployment (JobManager + TaskManagers) and
+# the submitter Job. Must be bound to an IAM role with read/write on the Flink
+# checkpoint bucket via EKS Pod Identity. Default is to create the SA here;
+# the lago-data Pulumi component sets `create: false` and provides `name` when
+# it owns the SA out-of-band (so it can wire it into the Pod Identity assoc).
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+submitter:
+  # Python image used by both the submitter Job AND the beam-py-harness sidecar
+  # on each TaskManager pod.
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+  # Annotations applied to the submitter Job.
+  annotations: {}
+  # Names of pre-existing Secrets the submitter Job consumes via envFrom.
+  # Provision them out-of-band (e.g. as SealedSecrets in the resources/ Argo
+  # source).
+  secrets:
+    # Postgres: SOURCE_DATABASE_URL, SINK_DATABASE_URL
+    postgres: ""
+    # Redpanda: KAFKA_BOOTSTRAP_SERVERS, KAFKA_SECURITY_PROTOCOL,
+    #           KAFKA_SASL_MECHANISM, KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD
+    kafka: ""
+  # Time-of-day (HH:MM) the daily revenue-recognition trigger fires, in each
+  # organisation's timezone.
+  triggerTime: "00:30"
+  kafka:
+    # Consumer group used by the submitter's organisation-cache bootstrap and by
+    # the FlinkRunner's source operators.
+    consumerGroup: "rev-rec"
+    # Where consumers start when no committed offset exists for the group.
+    # Use `earliest` for a one-off backfill, `latest` for steady-state.
+    autoOffsetReset: "latest"
+  logging:
+    # Log level for rev_rec's own loggers.
+    level: "INFO"
+    # Log level for noisy framework loggers (Beam expansion service, gRPC, etc.).
+    frameworkLevel: "WARNING"
+  # Beam overrides Flink's cluster-level checkpoint interval; without this set,
+  # Python ParDo bundles never close and no records flow out of the source.
+  checkpointingIntervalMs: 30000
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "1Gi"
+    limits:
+      cpu: "1"
+      memory: "4Gi"
+  # JVM tuning for the in-process Beam Java IO expansion service. Default direct
+  # buffer memory (~250MB) OOMs while streaming Beam SDK artifact jars over gRPC.
+  javaToolOptions: "-Xmx1500m -XX:MaxDirectMemorySize=1500m"
+  # How long completed/failed submitter Jobs are retained before garbage collection.
+  ttlSecondsAfterFinished: 1800
+  backoffLimit: 2
+  # Extra Beam pipeline options appended to the python -m run argv.
+  extraArgs: []


### PR DESCRIPTION
Deploys a Flink session cluster (HA, S3-backed checkpoints) plus a one-shot submitter Job for the Apache Beam revenue-recognition pipeline. Submitter runs as an ArgoCD `PostSync` hook so it waits for the FlinkDeployment to be Healthy.

Image repos+tags, secret names, and S3 paths are all required values — no defaults that imply environment.