### PR TITLE
Add scheduling controls to migration job

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,20 @@ You can use the provided `Taskfile.yaml` to easily set up a local development en
 
 **Note on Readiness Probes:** Currently, readiness probes are not explicitly configured for any of the components in this Helm chart.
 
+### Migration Job Configuration
+
+The database migration runs as a `pre-install`/`pre-upgrade` Helm hook Job. Use these
+to keep it schedulable on clusters with tainted or dedicated nodes.
+
+| Parameter                          | Description                                        | Default   |
+|-------------------------------------|----------------------------------------------------|-----------|
+| `job.migrate.tolerations`          | Pod tolerations for the migration Job             | `[]`      |
+| `job.migrate.nodeSelector`         | Node selector for the migration Job               | `{}`      |
+| `job.migrate.affinity`             | Affinity rules for the migration Job              | `{}`      |
+| `job.migrate.resources`            | Resource requests/limits for the migration Job    | `{}`      |
+| `job.migrate.extraEnv`             | Extra environment variables for the migration Job | `{}`      |
+| `job.migrate.loadSchema`           | Load the schema (`db:schema:load`) instead of running migrations | `false` |
+
 
 
 ### MinIO Configuration

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.27.1
+version: 1.28.0
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -19,6 +19,18 @@ spec:
       {{- end }}
     spec:
       restartPolicy: Never
+      {{- with .Values.job.migrate.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.job.migrate.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.job.migrate.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: lago-migrate
           image: getlago/api:v{{ .Values.version }}

--- a/charts/lago/tests/migrate_job_test.yaml
+++ b/charts/lago/tests/migrate_job_test.yaml
@@ -1,0 +1,53 @@
+suite: Test migration job scheduling controls
+templates:
+  - templates/migrate-job.yaml
+
+tests:
+  - it: has no scheduling constraints by default
+    set:
+      apiUrl: "https://api.lago.dev"
+      frontUrl: "https://app.lago.dev"
+      global.databaseUrl: "postgresql://lago:pw@db:5432/lago"
+      global.redisUrl: "redis://redis:6379"
+    asserts:
+      - isNull:
+          path: spec.template.spec.tolerations
+      - isNull:
+          path: spec.template.spec.nodeSelector
+      - isNull:
+          path: spec.template.spec.affinity
+
+  - it: sets tolerations, nodeSelector and affinity on the migration job
+    set:
+      apiUrl: "https://api.lago.dev"
+      frontUrl: "https://app.lago.dev"
+      global.databaseUrl: "postgresql://lago:pw@db:5432/lago"
+      global.redisUrl: "redis://redis:6379"
+      job.migrate.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: lago
+          effect: NoSchedule
+      job.migrate.nodeSelector:
+        disktype: ssd
+      job.migrate.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.template.spec.tolerations[0].effect
+          value: NoSchedule
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+      - isNotEmpty:
+          path: spec.template.spec.affinity.nodeAffinity

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -477,6 +477,9 @@ job:
     resources: {}
     extraEnv: {}
     loadSchema: false
+    tolerations: []
+    nodeSelector: {}
+    affinity: {}
   topics:
     resources: {}
     extraEnv: {}


### PR DESCRIPTION
Add tolerations, nodeSelector and affinity to the pre-install/pre-upgrade
database migration Job so it can be scheduled onto tainted or dedicated
nodes instead of being blocked. Defaults preserve current behavior (no
constraints emitted).

This allows us to adapt the chart to properly work with setups using tainted nodes and requires
tolerations on pods (e.g. GKE clusters using ARM64 nodes)

> This feature was implemented using Claude Opus 4.8
