### PR TITLE
feat: Deploy lago-data-agent

### DIFF
--- a/.github/workflows/chart-testing-lago-data-agent.yml
+++ b/.github/workflows/chart-testing-lago-data-agent.yml
@@ -1,0 +1,40 @@
+on:
+  pull_request:
+    paths:
+        - "charts/lago-data-agent/**"
+
+name: Lint Lago Data Agent Chart
+
+# NOTE: lint-only. The agent image lives in private ECR
+# (201661579678.dkr.ecr.us-east-1.amazonaws.com/lago-data-agent), so the `ct install`
+# step used by the mcp-server workflow would ImagePullBackOff in a throwaway kind
+# cluster. Add an install job once registry pull creds are wired into CI.
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --config ct.yaml

--- a/charts/lago-data-agent/.helmignore
+++ b/charts/lago-data-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lago-data-agent/Chart.yaml
+++ b/charts/lago-data-agent/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: lago-data-agent
+description: A Helm chart for the Lago Data Agent (text-to-SQL agent over the analytical DB)
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/charts/lago-data-agent/ci/basic-values.yaml
+++ b/charts/lago-data-agent/ci/basic-values.yaml
@@ -1,0 +1,19 @@
+# Minimal values so `ct lint` can render the chart.
+# Sensitive env (PG_DSN, AWS_BEARER_TOKEN_BEDROCK) is expected from `existingSecret`
+# in real environments; here we only need the template to render for linting.
+existingSecret: lago-data-agent
+
+image:
+  tag: ci
+
+extraEnv:
+  - name: BEDROCK_MODEL_ID
+    value: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+  - name: AWS_DEFAULT_REGION
+    value: us-east-1
+  - name: LAGO_API_URL
+    value: http://lago-api.default.svc.cluster.local/api/v1
+
+extraEnvFrom:
+  - secretRef:
+      name: lago-data-agent

--- a/charts/lago-data-agent/templates/_helpers.tpl
+++ b/charts/lago-data-agent/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lago-data-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lago-data-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lago-data-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lago-data-agent.labels" -}}
+helm.sh/chart: {{ include "lago-data-agent.chart" . }}
+{{ include "lago-data-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lago-data-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lago-data-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lago-data-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lago-data-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the name of the secret
+*/}}
+{{- define "lago-data-agent.secretName" -}}
+{{- if .Values.existingSecret }}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "lago-data-agent.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/lago-data-agent/templates/deployment.yaml
+++ b/charts/lago-data-agent/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lago-data-agent.fullname" . }}
+  labels:
+    {{- include "lago-data-agent.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lago-data-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lago-data-agent.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lago-data-agent.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ default .Chart.Name .Values.container.name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{ toJson .Values.container.command }}
+          args: {{ toJson .Values.container.args }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.container.ports.http }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lago-data-agent/templates/hpa.yaml
+++ b/charts/lago-data-agent/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lago-data-agent.fullname" . }}
+  labels:
+    {{- include "lago-data-agent.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lago-data-agent.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/lago-data-agent/templates/service.yaml
+++ b/charts/lago-data-agent/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lago-data-agent.fullname" . }}
+  labels:
+    {{- include "lago-data-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lago-data-agent.selectorLabels" . | nindent 4 }}

--- a/charts/lago-data-agent/templates/serviceaccount.yaml
+++ b/charts/lago-data-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lago-data-agent.serviceAccountName" . }}
+  labels:
+    {{- include "lago-data-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/lago-data-agent/values.yaml
+++ b/charts/lago-data-agent/values.yaml
@@ -1,0 +1,146 @@
+# Default values for lago-data-agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Name of a pre-existing Secret (e.g. a SealedSecret-managed one) whose keys are
+# exposed to the container. The agent's sensitive values (PG_DSN, AWS_BEARER_TOKEN_BEDROCK)
+# are expected to come from this secret, referenced via `extraEnvFrom` below.
+existingSecret: ""
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  # Pushed by lago-data/.github/workflows/build-agent-image.yml
+  repository: 201661579678.dkr.ecr.us-east-1.amazonaws.com/lago-data-agent
+
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+container:
+  name: ""
+  # The agent image backs two entrypoints; `api` is the MCP-facing POST /ask service
+  # (X-LAGO-API-KEY auth) + unauthenticated /health. See agent/Dockerfile.
+  command: ["python", "-m", "src"]
+  args: ["api", "--host", "0.0.0.0", "--port", "8000"]
+  ports:
+    http: 8000
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account.
+  # NOTE: if Bedrock access moves from AWS_BEARER_TOKEN_BEDROCK to IAM/Pod Identity,
+  # the IRSA / Pod Identity role association would be wired here.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# the image runs as a fixed non-root uid (10001) baked into the Dockerfile
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 10001
+
+# /health is unauthenticated (see agent/Dockerfile). Probes hit it on the http port.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Environment variables to pass to the agent container (non-sensitive).
+# e.g. BEDROCK_MODEL_ID, AWS_DEFAULT_REGION, LAGO_API_URL — set per-env in lago-deploy.
+extraEnv: []
+  # - name: "MY_VAR"
+  #   value: "value"
+
+# -- envFrom to pass to the agent container.
+# Used to pull the sensitive env (PG_DSN, AWS_BEARER_TOKEN_BEDROCK) from `existingSecret`.
+# @default -- `[]` (See [values.yaml])
+extraEnvFrom: []
+  # - secretRef:
+  #     name: lago-data-agent
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
  ## Add `lago-data-agent` Helm chart

  New chart for the Lago Data Agent (HTTP service, `agent/` in lago-data), modeled on `lago-mcp-server`.

  - `charts/lago-data-agent/` — ECR image, `python -m src api` on :8000, `/health` liveness+readiness, generic `extraEnv`/`extraEnvFrom` (no hardcoded secrets).
  - `.github/workflows/chart-testing-lago-data-agent.yml` — **lint-only** (image is private ECR, so `ct install` would ImagePullBackOff).

  `helm lint` passes. No image build needed here — `lago-data/build-agent-image.yml` already pushes to ECR.