### PR TITLE
feat(charts): support Deployment metadata annotations on every deployment

### DIFF
--- a/charts/lago-data-api/README.md
+++ b/charts/lago-data-api/README.md
@@ -53,6 +53,7 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` | Number of replicas (ignored when autoscaling is enabled) |
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Image
 

--- a/charts/lago-data-api/templates/deployment.yaml
+++ b/charts/lago-data-api/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-data-api.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-data-api.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-data-api/values.yaml
+++ b/charts/lago-data-api/values.yaml
@@ -71,6 +71,10 @@ image:
 # @default -- `[]`
 # @section -- Image
 imagePullSecrets: []
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/charts/lago-data-worker/README.md
+++ b/charts/lago-data-worker/README.md
@@ -73,6 +73,7 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` | Number of replicas (ignored when autoscaling is enabled) |
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Image
 

--- a/charts/lago-data-worker/templates/deployment.yaml
+++ b/charts/lago-data-worker/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-data-worker.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-data-worker.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-data-worker/values.yaml
+++ b/charts/lago-data-worker/values.yaml
@@ -106,6 +106,10 @@ image:
 # @default -- `[]`
 # @section -- Image
 imagePullSecrets: []
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/charts/lago-events-processor-worker/README.md
+++ b/charts/lago-events-processor-worker/README.md
@@ -41,6 +41,7 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` | Number of replicas (ignored when autoscaling is enabled) |
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Image
 

--- a/charts/lago-events-processor-worker/templates/deployment.yaml
+++ b/charts/lago-events-processor-worker/templates/deployment.yaml
@@ -5,6 +5,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-events-processor-worker.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-events-processor-worker.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-events-processor-worker/values.yaml
+++ b/charts/lago-events-processor-worker/values.yaml
@@ -159,6 +159,10 @@ image:
 # @default -- `[]`
 # @section -- Image
 imagePullSecrets: []
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/charts/lago-front/README.md
+++ b/charts/lago-front/README.md
@@ -68,6 +68,7 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` | Number of replicas (ignored when autoscaling is enabled) |
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Image
 

--- a/charts/lago-front/templates/deployment.yaml
+++ b/charts/lago-front/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-front.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-front.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-front/values.yaml
+++ b/charts/lago-front/values.yaml
@@ -75,6 +75,10 @@ image:
 # @default -- `[]`
 # @section -- Image
 imagePullSecrets: []
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/charts/lago-mcp-server/README.md
+++ b/charts/lago-mcp-server/README.md
@@ -31,6 +31,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Container
 

--- a/charts/lago-mcp-server/templates/deployment.yaml
+++ b/charts/lago-mcp-server/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-mcp-server.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-mcp-server.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-mcp-server/values.yaml
+++ b/charts/lago-mcp-server/values.yaml
@@ -37,6 +37,10 @@ image:
 # @default -- `[]`
 # @section -- Image
 imagePullSecrets: []
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/charts/lago-pdf/README.md
+++ b/charts/lago-pdf/README.md
@@ -86,6 +86,7 @@ A Helm chart for the Lago PDF stack (Gotenberg + optional Rails worker)
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Extra Objects
 

--- a/charts/lago-pdf/templates/deployment.yaml
+++ b/charts/lago-pdf/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-pdf.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-pdf.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-pdf/values.yaml
+++ b/charts/lago-pdf/values.yaml
@@ -496,6 +496,10 @@ gotenberg:
   # @section -- Gotenberg
   fullnameOverride: ""
 
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/charts/lago-rails/README.md
+++ b/charts/lago-rails/README.md
@@ -53,6 +53,7 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` | Number of replicas (ignored when autoscaling is enabled) |
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
+| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Image
 

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "lago-rails.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "lago-rails.labels" . | nindent 4 }}
 spec:

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -400,6 +400,10 @@ image:
 # @default -- `[]`
 # @section -- Image
 imagePullSecrets: []
+# -- Deployment metadata annotations (e.g. Stakater Reloader)
+# @section -- Deployment
+annotations: {}
+
 # -- Override the chart name
 # @section -- Deployment
 nameOverride: ""

--- a/tests-common/deployment/common_patterns_test.yaml
+++ b/tests-common/deployment/common_patterns_test.yaml
@@ -144,6 +144,33 @@ tests:
           path: spec.template.spec.topologySpreadConstraints
 
   # ============================================================================
+  # Deployment Annotations Tests
+  # ============================================================================
+  - it: should include Deployment annotations when specified
+    values:
+      - ./fixtures/required.yaml
+    set:
+      annotations:
+        reloader.stakater.com/auto: "true"
+        custom.example.com/owner: "platform"
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["custom.example.com/owner"]
+          value: "platform"
+
+  - it: should not include Deployment annotations when empty
+    values:
+      - ./fixtures/required.yaml
+    set:
+      annotations: {}
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  # ============================================================================
   # Combined Test - All Common Patterns
   # ============================================================================
   - it: should correctly render all common patterns together


### PR DESCRIPTION
## Summary
- Adds a new top-level `annotations: {}` value to every deployment-bearing subchart (`lago-rails`, `lago-front`, `lago-pdf`, `lago-events-processor-worker`, `lago-data-api`, `lago-data-worker`, `lago-mcp-server`) and renders it as the Deployment's `metadata.annotations`.
- Closes the gap that prevented controllers like [Stakater Reloader](https://github.com/stakater/Reloader) from working with these deployments — `podAnnotations` was the only existing hook, and it lands on the pod template, not the Deployment, so Reloader never saw the annotation it needs to roll the pods on cm/secret changes.
- With this in, the umbrella `lago` chart can opt subcharts into Reloader (or any other Deployment-level annotation) via `<subchart>.annotations: { reloader.stakater.com/auto: "true" }`.

## Test plan
- [x] `task test:unit` — all charts pass; the new `tests-common/deployment/common_patterns_test.yaml` assertions cover the "set" and "empty" cases
- [ ] Render the umbrella chart locally with `annotations: { reloader.stakater.com/auto: "true" }` on `api` and confirm the Deployment manifest carries the annotation at `metadata.annotations`