### PR TITLE
fix(lago): default global.urls.pdf to http://lago-pdf

### DIFF
--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -61,9 +61,11 @@ global:
     # -- Public URL of the Lago frontend
     # @section -- URLs
     front: ""
-    # -- Internal URL of the PDF service (Gotenberg)
+    # -- Internal URL of the PDF service (Gotenberg). Must include a scheme
+    # because lago-api joins this with a path via `URI.join`, which raises
+    # `URI::BadURIError: both URI are relative` if the value is scheme-less.
     # @section -- URLs
-    pdf: "lago-pdf"
+    pdf: "http://lago-pdf"
 
   database:
     # -- PostgreSQL connection URI


### PR DESCRIPTION
## Summary
- `global.urls.pdf` defaults to `"lago-pdf"` — scheme-less — and gets propagated to lago-api as `LAGO_PDF_URL`.
- lago-api builds the Gotenberg request URL via [`URI.join(ENV["LAGO_PDF_URL"], "/forms/chromium/convert/html")`](https://github.com/getlago/lago-api/blob/main/app/services/utils/pdf_generator.rb#L32). Without a scheme on the left, both URIs are relative and the join raises `URI::BadURIError: both URI are relative` — every `Invoices::GenerateDocumentsJob` fails on a freshly-provisioned cluster (caught on staging-eu-1).
- This PR changes the default to `"http://lago-pdf"`. Existing envs that already set `global.urls.pdf` to a custom value are unaffected.

## Test plan
- [x] `task test:unit` — all 9 chart test suites pass
- [ ] Render the umbrella chart, confirm the `lago-config` ConfigMap now contains `pdf.endpoint: http://lago-pdf`
- [ ] After release, redeploy staging-eu-1 and confirm `Invoices::GenerateDocumentsJob` succeeds end-to-end