### PR TITLE
Support custom image registry and authenticated pulls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ You can use the provided `Taskfile.yaml` to easily set up a local development en
 | `global.signup.enabled`          | Enable or disable Lago's signup feature                                                                 | `true`            |
 | `global.googleAuth.enabled`      | Enable or disable logging through Google Auth                                                           | `true`            |
 | `global.ingress.enabled`         | Enable ingress resources for the application                                                            | `false`           |
+| `global.image.registry`          | Registry/mirror for all chart-managed images (getlago/*, alpine). Override to use a private registry or pull-through mirror | `docker.io`       |
+| `global.imagePullSecrets`        | Pull secrets applied to every chart-managed pod (e.g. `[{name: my-cred}]`); required for authenticated registries/mirrors | `[]`              |
 | `global.kubectl.imageRegistry`   | Docker registry with kubectl image (for init containers)                                                | `docker.io`       |
 | `global.kubectl.imageRepository` | Docker repository with kubectl image (for init containers)                                              | `rancher/kubectl` |
 | `global.kubectl.imageTag`        | Tag of kubectl Docker image (for init containers) - if unset (default) it is set to k8s cluster version | `""`              |

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.27.1
+version: 1.28.0
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.api.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -241,7 +245,7 @@ spec:
             {{- include "kafkaEnvs" . | nindent 12 }}
             {{- include "clickhouseEnvs" . | nindent 12 }}
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-api
           ports:
             - name: http

--- a/charts/lago/templates/billing-worker-deployment.yaml
+++ b/charts/lago/templates/billing-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.billingWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -208,7 +212,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-billing-worker
           {{- if .Values.billingWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/clock-deployment.yaml
+++ b/charts/lago/templates/clock-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clock.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -105,7 +109,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-clock
           {{- with .Values.clock.resources }}
           resources:

--- a/charts/lago/templates/clock-worker-deployment.yaml
+++ b/charts/lago/templates/clock-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clockWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -190,7 +194,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-clock-worker
           {{- if .Values.clockWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/create-topic-job.yaml
+++ b/charts/lago/templates/create-topic-job.yaml
@@ -19,10 +19,14 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: create-topics
-          image: alpine:3.20
+          image: {{ .Values.global.image.registry }}/library/alpine:3.20
           command: [sh]
           args:
             - -c

--- a/charts/lago/templates/events-consumer-worker-deployment.yaml
+++ b/charts/lago/templates/events-consumer-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.eventsConsumer.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -38,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-events-consumer-worker
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           command: ["./scripts/start.events.consumer.sh"]
         {{- with .Values.eventsConsumer.resources }}
           resources:

--- a/charts/lago/templates/events-processor-worker-deployment.yaml
+++ b/charts/lago/templates/events-processor-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.eventsProcessor.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -38,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-events-processor-worker
-          image: getlago/lago-events-processor:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/lago-events-processor:v{{ .Values.version }}
           command: ["./event_processors"]
         {{- with .Values.eventsProcessor.resources }}
           resources:

--- a/charts/lago/templates/events-worker-deployment.yaml
+++ b/charts/lago/templates/events-worker-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.eventsWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -111,7 +115,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-events-worker
           {{- with .Values.eventsWorker.resources }}
           resources:

--- a/charts/lago/templates/front-deployment.yaml
+++ b/charts/lago/templates/front-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.front.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -53,7 +57,7 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-          image: getlago/front:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/front:v{{ .Values.version }}
           name: {{ .Release.Name }}-front
           ports:
             - containerPort: 80

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -18,10 +18,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: lago-migrate
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           {{ if .Values.job.migrate.loadSchema }}
           command: ["bin/rails"]
           args:

--- a/charts/lago/templates/payment-worker-deployment.yaml
+++ b/charts/lago/templates/payment-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.paymentWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -208,7 +212,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-payment-worker
           {{- if .Values.paymentWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/pdf-deployment.yaml
+++ b/charts/lago/templates/pdf-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.pdf.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -37,7 +41,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: getlago/lago-gotenberg:8.15
+        - image: {{ .Values.global.image.registry }}/getlago/lago-gotenberg:8.15
           name: {{ .Release.Name }}-pdf
           ports:
             - containerPort: 3000

--- a/charts/lago/templates/pdf-worker-deployment.yaml
+++ b/charts/lago/templates/pdf-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.pdfWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -208,7 +212,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-pdf-worker
           {{- if .Values.pdfWorker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/templates/webhook-worker-deployment.yaml
+++ b/charts/lago/templates/webhook-worker-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.webhookWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -114,7 +118,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-webhook-worker
           {{- with .Values.webhookWorker.resources }}
           resources:

--- a/charts/lago/templates/worker-deployment.yaml
+++ b/charts/lago/templates/worker-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -207,7 +211,7 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: newRelicKey
             {{ end }}
-          image: getlago/api:v{{ .Values.version }}
+          image: {{ .Values.global.image.registry }}/getlago/api:v{{ .Values.version }}
           name: {{ .Release.Name }}-worker
           {{- if .Values.worker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -83,6 +83,11 @@ global:
     egress: []
     ingress: []
 
+  image:
+    registry: docker.io
+
+  imagePullSecrets: []
+
   kubectl:
     imageRegistry: docker.io
     imageRepository: rancher/kubectl


### PR DESCRIPTION
# Make image registry and imagePullSecrets configurable

## Summary

Adds two new global values so all chart-managed images can be pulled from a custom registry/mirror with authentication, instead of being hard-wired to anonymous Docker Hub:

- `global.image.registry` (default `docker.io`) — prepended to every chart-managed image (`getlago/api`, `getlago/front`, `getlago/lago-events-processor`, `getlago/lago-gotenberg`, and the `alpine` create-topics image).
- `global.imagePullSecrets` (default `[]`) — rendered into every pod spec, for registries/mirrors that require authentication.

Both default to the current behavior, so this is fully backward compatible.

## Motivation

The image references are currently hard-coded (e.g. `getlago/api:v{{ .Values.version }}`), and the chart never renders `imagePullSecrets` on any pod. That makes it impossible to:

- pull images through a private registry or a pull-through cache/mirror, and
- authenticate those pulls.

In practice this causes deployments to depend on unauthenticated Docker Hub pulls. During node rotations (e.g. a Kubernetes upgrade, where pods land on fresh nodes with a cold image cache and re-pull everything), this can hit Docker Hub's anonymous pull-rate limit and leave pods stuck in `ImagePullBackOff`. Pointing the chart at an authenticated mirror resolves this.

## Changes

- `values.yaml`: add `global.image.registry` and `global.imagePullSecrets`, documented inline.
- All workload/job templates: prefix the image with `{{ .Values.global.image.registry }}/…` (`alpine` → `library/alpine`). The kubectl init-container image is left as-is since it already has `global.kubectl.imageRegistry`.
- All pod specs: add an `imagePullSecrets` block using the chart's existing `{{- with … }}` / `nindent` style (same pattern as the `tolerations`/`affinity` blocks), so nothing is rendered when the value is unset.
- `Chart.yaml`: bump version to `1.28.0`.
- `README.md`: document the two new parameters.

## Example

```yaml
global:
  image:
    registry: registry.example.io/docker.io   # pull-through mirror
  imagePullSecrets:
    - name: my-registry-cred
```

## Notes

- Defaults unchanged → existing installs are unaffected.
- Related prior art: #204 and #198 (registry configurability only). This PR additionally covers `imagePullSecrets`, and consolidates both into one change. Also relevant: #203.
- closes https://github.com/getlago/lago-helm-charts/issues/197