### PR TITLE
feat(charts): add lago-data-superset chart

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -14,6 +14,7 @@ CHARTS=(
   lago-data-worker
   lago-data-forecasted-usage
   lago-data-rev-rec
+  lago-data-superset
   lago-mcp-server
   lago-pdf
   lago-data

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ charts/
   lago-data-worker/               # Data worker (Celery)
   lago-data-config/               # Data shared config
   lago-data-forecasted-usage/     # ML forecasting CronJob
+  lago-data-superset/             # Superset analytics dashboards (web + worker)
   lago-staging/                   # Staging umbrella (Lago + Data + deps)
 ```
 
@@ -96,6 +97,7 @@ Each chart has a `values.yaml` with full documentation. See the individual chart
 | [lago-data-api](./charts/lago-data-api/README.md) | Data API |
 | [lago-data-worker](./charts/lago-data-worker/README.md) | Data worker |
 | [lago-data-forecasted-usage](./charts/lago-data-forecasted-usage/README.md) | ML forecasting CronJob |
+| [lago-data-superset](./charts/lago-data-superset/README.md) | Superset analytics dashboards (web + worker) |
 
 ## Development
 

--- a/charts/lago-data-superset/Chart.yaml
+++ b/charts/lago-data-superset/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: lago-data-superset
+description: >-
+  Lago's custom Apache Superset — a content-free machinery image plus a separate
+  assets image staged into /assets by an init-container. Config is fully decoupled:
+  all env is supplied via extraEnv / extraEnvFrom.
+type: application
+version: 0.5.9
+# Tracks the upstream Apache Superset the machinery image is built on.
+appVersion: "6.0.0"

--- a/charts/lago-data-superset/README.md
+++ b/charts/lago-data-superset/README.md
@@ -1,0 +1,99 @@
+# lago-data-superset
+
+![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.0.0](https://img.shields.io/badge/AppVersion-6.0.0-informational?style=flat-square)
+
+Lago's custom Apache Superset — a content-free machinery image plus a separate assets image staged into /assets by an init-container. Config is fully decoupled: all env is supplied via extraEnv / extraEnvFrom.
+
+## Values
+
+### Image
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.repository | string | `""` | Machinery image repository (data/superset) |
+| image.tag | string | `""` | Machinery image tag |
+| image.pullPolicy | string | `"IfNotPresent"` | Machinery image pull policy |
+| assets.repository | string | `""` | Assets image repository (data/superset-config) |
+| assets.tag | string | `""` | Assets image tag |
+| assets.pullPolicy | string | `"IfNotPresent"` | Assets image pull policy |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries |
+
+### Deployment
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| annotations | object | `{}` | Annotations applied to the Deployment resources |
+| labels | object | `{}` | Additional labels merged onto all resources |
+
+### Service Account
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| serviceAccount.create | bool | `true` | Create a ServiceAccount |
+| serviceAccount.automount | bool | `true` | Automount the ServiceAccount API credentials |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
+| serviceAccount.name | string | `""` | ServiceAccount name (generated from fullname when create is true; required when create is false) |
+
+### Service
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| service.type | string | `"ClusterIP"` | Service type |
+| service.port | int | `8088` | Service port (the web container listens on 8088) |
+
+### Web
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| web.replicaCount | int | `1` | Web (API/UI) replica count |
+| web.resources | object | `{}` | Web container resources |
+| web.startupProbe | object | `{"failureThreshold":60,"httpGet":{"path":"/health","port":"http"},"periodSeconds":10}` | Web startup probe (boot runs migrations + bundle import, so allow a generous window) |
+| web.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"periodSeconds":15}` | Web liveness probe |
+| web.readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"periodSeconds":15}` | Web readiness probe |
+
+### Worker
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| worker.replicaCount | int | `1` | Celery worker replica count |
+| worker.resources | object | `{}` | Worker container resources |
+
+### Config
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| config.superset.secretKey.secretRef | object | `{"name":""}` | Secret containing SUPERSET_SECRET_KEY (required) |
+| config.superset.metadataDb.uri.secretRef | object | `{"name":""}` | Secret containing SUPERSET_METADATA_DB_URI |
+| config.superset.metadataDb.poolSize | int | `20` | SUPERSET_METADATA_DB_POOL_SIZE |
+| config.superset.metadataDb.maxOverflow | int | `40` | SUPERSET_METADATA_DB_MAX_OVERFLOW |
+| config.superset.metadataDb.poolTimeout | int | `60` | SUPERSET_METADATA_DB_POOL_TIMEOUT |
+| config.superset.redis.secretRef | object | `{"name":""}` | Secret containing SUPERSET_REDIS_URL |
+| config.superset.admin.secretRef | object | `{"name":""}` | Secret containing SUPERSET_ADMIN_USERNAME, _PASSWORD, _FIRSTNAME, _LASTNAME, _EMAIL |
+| config.superset.env | string | `"production"` | SUPERSET_ENV |
+| config.superset.celery.concurrency | int | `4` | SUPERSET_CELERY_CONCURRENCY |
+| config.superset.celery.logLevel | string | `"info"` | SUPERSET_CELERY_LOG_LEVEL |
+| config.superset.corsOrigins | string | `"https://eu.getlago.com"` | SUPERSET_CORS_ORIGINS |
+| config.superset.guestRole | string | `"LagoViewer"` | SUPERSET_GUEST_ROLE |
+| config.superset.jwtExpireMinutes | int | `300` | SUPERSET_JWT_EXPIRE_MINUTES |
+| config.superset.cacheDefaultTimeout | int | `86400` | SUPERSET_CACHE_DEFAULT_TIMEOUT |
+| config.superset.logLevel | string | `"INFO"` | SUPERSET_LOG_LEVEL |
+| config.superset.localSsl | bool | `false` | SUPERSET_LOCAL_SSL |
+| config.lago.bundles | string | `""` | LAGO_BUNDLES: comma-separated bundle keys to activate (empty → import nothing) |
+| config.lago.prune | bool | `true` | LAGO_PRUNE: converge to desired state after import |
+
+### Pod
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraEnv | object | `{}` | Extra environment variables (map; each value is a string, or a map for valueFrom) |
+| extraEnvFrom | list | `[]` | Extra envFrom sources (e.g. for LAGO_DATASOURCE_* and other operator-injected config) |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{}` | Pod security context |
+| securityContext | object | `{}` | Container security context |
+| nodeSelector | object | `{}` | Node selector |
+| affinity | object | `{}` | Affinity rules |
+| tolerations | list | `[]` | Tolerations |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/lago-data-superset/templates/_helpers.tpl
+++ b/charts/lago-data-superset/templates/_helpers.tpl
@@ -1,0 +1,114 @@
+{{- define "lago-data-superset.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "lago-data-superset.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "lago-data-superset.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "lago-data-superset.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "lago-data-superset.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "lago-data-superset.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Machinery image (data/superset) — repo+tag required, no baked-in default. */}}
+{{- define "lago-data-superset.image" -}}
+{{- $repo := required "image.repository is required" .Values.image.repository -}}
+{{- $tag  := required "image.tag is required"        .Values.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/* Assets image (data/superset-config) staged into /assets by the init-container. */}}
+{{- define "lago-data-superset.assetsImage" -}}
+{{- $repo := required "assets.repository is required" .Values.assets.repository -}}
+{{- $tag  := required "assets.tag is required"        .Values.assets.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
+The stage-assets init-container: runs the busybox assets image and copies its
+baked /assets tree into the shared `assets` emptyDir, which the app then mounts
+read-only at /assets (the machinery's fixed ASSETS_DIR).
+*/}}
+{{- define "lago-data-superset.initContainers" -}}
+- name: stage-assets
+  image: {{ include "lago-data-superset.assetsImage" . | quote }}
+  imagePullPolicy: {{ .Values.assets.pullPolicy }}
+  command: ["sh", "-c", "cp -a /assets/. /assets-shared/"]
+  volumeMounts:
+    - name: assets
+      mountPath: /assets-shared
+{{- end -}}
+
+{{/* envFrom + env blocks shared by web and worker. */}}
+{{- define "lago-data-superset.env" -}}
+envFrom:
+  - secretRef:
+      name: {{ required "config.superset.secretKey.secretRef.name is required" .Values.config.superset.secretKey.secretRef.name }}
+  {{- with .Values.config.superset.metadataDb.uri.secretRef.name }}
+  - secretRef:
+      name: {{ . }}
+  {{- end }}
+  {{- with .Values.config.superset.redis.secretRef.name }}
+  - secretRef:
+      name: {{ . }}
+  {{- end }}
+  {{- with .Values.config.superset.admin.secretRef.name }}
+  - secretRef:
+      name: {{ . }}
+  {{- end }}
+  {{- with .Values.extraEnvFrom }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+env:
+  - name: SUPERSET_ENV
+    value: {{ .Values.config.superset.env | quote }}
+  - name: SUPERSET_METADATA_DB_POOL_SIZE
+    value: {{ .Values.config.superset.metadataDb.poolSize | toString | quote }}
+  - name: SUPERSET_METADATA_DB_MAX_OVERFLOW
+    value: {{ .Values.config.superset.metadataDb.maxOverflow | toString | quote }}
+  - name: SUPERSET_METADATA_DB_POOL_TIMEOUT
+    value: {{ .Values.config.superset.metadataDb.poolTimeout | toString | quote }}
+  - name: SUPERSET_CELERY_CONCURRENCY
+    value: {{ .Values.config.superset.celery.concurrency | toString | quote }}
+  - name: SUPERSET_CELERY_LOG_LEVEL
+    value: {{ .Values.config.superset.celery.logLevel | quote }}
+  - name: SUPERSET_CORS_ORIGINS
+    value: {{ required "config.superset.corsOrigins is required" .Values.config.superset.corsOrigins | quote }}
+  - name: SUPERSET_GUEST_ROLE
+    value: {{ .Values.config.superset.guestRole | quote }}
+  - name: SUPERSET_JWT_EXPIRE_MINUTES
+    value: {{ .Values.config.superset.jwtExpireMinutes | toString | quote }}
+  - name: SUPERSET_CACHE_DEFAULT_TIMEOUT
+    value: {{ .Values.config.superset.cacheDefaultTimeout | toString | quote }}
+  - name: SUPERSET_LOG_LEVEL
+    value: {{ .Values.config.superset.logLevel | quote }}
+  - name: SUPERSET_LOCAL_SSL
+    value: {{ .Values.config.superset.localSsl | toString | quote }}
+  - name: LAGO_BUNDLES
+    value: {{ .Values.config.lago.bundles | quote }}
+  - name: LAGO_PRUNE
+    value: {{ .Values.config.lago.prune | toString | quote }}
+  {{- range $name, $val := .Values.extraEnv }}
+  {{- if kindIs "map" $val }}
+  - name: {{ $name }}
+    {{- toYaml $val | nindent 4 }}
+  {{- else }}
+  - name: {{ $name }}
+    value: {{ $val | quote }}
+  {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/lago-data-superset/templates/deployment.yaml
+++ b/charts/lago-data-superset/templates/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lago-data-superset.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lago-data-superset.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "lago-data-superset.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lago-data-superset.serviceAccountName" . }}
+      enableServiceLinks: false
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- include "lago-data-superset.initContainers" . | nindent 8 }}
+      containers:
+        - name: superset
+          image: {{ include "lago-data-superset.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-u", "/app/run.py", "api"]
+          {{- include "lago-data-superset.env" . | nindent 10 }}
+          ports:
+            - name: http
+              containerPort: 8088
+              protocol: TCP
+          volumeMounts:
+            - name: assets
+              mountPath: /assets
+              readOnly: true
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: assets
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lago-data-superset/templates/service.yaml
+++ b/charts/lago-data-superset/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lago-data-superset.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-superset.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lago-data-superset.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/lago-data-superset/templates/serviceaccount.yaml
+++ b/charts/lago-data-superset/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lago-data-superset.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-superset.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/lago-data-superset/templates/worker-deployment.yaml
+++ b/charts/lago-data-superset/templates/worker-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lago-data-superset.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lago-data-superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lago-data-superset.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "lago-data-superset.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lago-data-superset.serviceAccountName" . }}
+      enableServiceLinks: false
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- include "lago-data-superset.initContainers" . | nindent 8 }}
+      containers:
+        - name: superset-worker
+          image: {{ include "lago-data-superset.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-u", "/app/run.py", "worker"]
+          {{- include "lago-data-superset.env" . | nindent 10 }}
+          volumeMounts:
+            - name: assets
+              mountPath: /assets
+              readOnly: true
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: assets
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lago-data-superset/values.yaml
+++ b/charts/lago-data-superset/values.yaml
@@ -1,0 +1,201 @@
+# Default values for lago-data-superset.
+#
+# Non-sensitive platform config (SUPERSET_*, LAGO_BUNDLES, LAGO_PRUNE) is typed
+# under config.superset.* and config.lago.*. Credentials are injected via
+# per-domain secretRef entries rendered as envFrom. LAGO_DATASOURCE_* and any
+# other operator-managed env flows through extraEnv / extraEnvFrom.
+
+# Machinery image (data/superset): content-free Superset that reads its assets
+# from /assets at boot.
+image:
+  # -- Machinery image repository (data/superset)
+  # @section -- Image
+  repository: ""
+  # -- Machinery image tag
+  # @section -- Image
+  tag: ""
+  # -- Machinery image pull policy
+  # @section -- Image
+  pullPolicy: IfNotPresent
+
+# Assets image (data/superset-config): a busybox image carrying the assets/ tree
+# at /assets, staged into a shared volume by an init-container.
+assets:
+  # -- Assets image repository (data/superset-config)
+  # @section -- Image
+  repository: ""
+  # -- Assets image tag
+  # @section -- Image
+  tag: ""
+  # -- Assets image pull policy
+  # @section -- Image
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+# @section -- Image
+imagePullSecrets: []
+
+# -- Annotations applied to the Deployment resources
+# @section -- Deployment
+annotations: {}
+# -- Additional labels merged onto all resources
+# @section -- Deployment
+labels: {}
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  # @section -- Service Account
+  create: true
+  # -- Automount the ServiceAccount API credentials
+  # @section -- Service Account
+  automount: true
+  # -- Annotations to add to the ServiceAccount
+  # @section -- Service Account
+  annotations: {}
+  # -- ServiceAccount name (generated from fullname when create is true; required when create is false)
+  # @section -- Service Account
+  name: ""
+
+service:
+  # -- Service type
+  # @section -- Service
+  type: ClusterIP
+  # -- Service port (the web container listens on 8088)
+  # @section -- Service
+  port: 8088
+
+web:
+  # -- Web (API/UI) replica count
+  # @section -- Web
+  replicaCount: 1
+  # -- Web container resources
+  # @section -- Web
+  resources: {}
+  # -- Web startup probe (boot runs migrations + bundle import, so allow a generous window)
+  # @section -- Web
+  startupProbe:
+    httpGet:
+      path: /health
+      port: http
+    periodSeconds: 10
+    failureThreshold: 60
+  # -- Web liveness probe
+  # @section -- Web
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    periodSeconds: 15
+  # -- Web readiness probe
+  # @section -- Web
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    periodSeconds: 15
+
+worker:
+  # -- Celery worker replica count
+  # @section -- Worker
+  replicaCount: 1
+  # -- Worker container resources
+  # @section -- Worker
+  resources: {}
+
+config:
+  superset:
+    secretKey:
+      # -- Secret containing SUPERSET_SECRET_KEY (required)
+      # @section -- Config
+      secretRef:
+        name: ""
+    metadataDb:
+      uri:
+        # -- Secret containing SUPERSET_METADATA_DB_URI
+        # @section -- Config
+        secretRef:
+          name: ""
+      # -- SUPERSET_METADATA_DB_POOL_SIZE
+      # @section -- Config
+      poolSize: 20
+      # -- SUPERSET_METADATA_DB_MAX_OVERFLOW
+      # @section -- Config
+      maxOverflow: 40
+      # -- SUPERSET_METADATA_DB_POOL_TIMEOUT
+      # @section -- Config
+      poolTimeout: 60
+    redis:
+      # -- Secret containing SUPERSET_REDIS_URL
+      # @section -- Config
+      secretRef:
+        name: ""
+    admin:
+      # -- Secret containing SUPERSET_ADMIN_USERNAME, _PASSWORD, _FIRSTNAME, _LASTNAME, _EMAIL
+      # @section -- Config
+      secretRef:
+        name: ""
+    # -- SUPERSET_ENV
+    # @section -- Config
+    env: production
+    celery:
+      # -- SUPERSET_CELERY_CONCURRENCY
+      # @section -- Config
+      concurrency: 4
+      # -- SUPERSET_CELERY_LOG_LEVEL
+      # @section -- Config
+      logLevel: info
+    # -- SUPERSET_CORS_ORIGINS (required — comma-separated allowed embed origins)
+    # @section -- Config
+    corsOrigins: ""
+    # -- SUPERSET_GUEST_ROLE
+    # @section -- Config
+    guestRole: "LagoViewer"
+    # -- SUPERSET_JWT_EXPIRE_MINUTES
+    # @section -- Config
+    jwtExpireMinutes: 300
+    # -- SUPERSET_CACHE_DEFAULT_TIMEOUT
+    # @section -- Config
+    cacheDefaultTimeout: 86400
+    # -- SUPERSET_LOG_LEVEL
+    # @section -- Config
+    logLevel: INFO
+    # -- SUPERSET_LOCAL_SSL
+    # @section -- Config
+    localSsl: false
+  lago:
+    # -- LAGO_BUNDLES: comma-separated bundle keys to activate (empty → import nothing)
+    # @section -- Config
+    bundles: ""
+    # -- LAGO_PRUNE: converge to desired state after import
+    # @section -- Config
+    prune: true
+
+# -- Extra environment variables (map; each value is a string, or a map for valueFrom)
+# @section -- Pod
+extraEnv: {}
+# -- Extra envFrom sources (e.g. for LAGO_DATASOURCE_* and other operator-injected config)
+# @default -- `[]`
+# @section -- Pod
+extraEnvFrom: []
+
+# -- Pod annotations
+# @section -- Pod
+podAnnotations: {}
+# -- Pod labels
+# @section -- Pod
+podLabels: {}
+# -- Pod security context
+# @section -- Pod
+podSecurityContext: {}
+# -- Container security context
+# @section -- Pod
+securityContext: {}
+# -- Node selector
+# @section -- Pod
+nodeSelector: {}
+# -- Affinity rules
+# @section -- Pod
+affinity: {}
+# -- Tolerations
+# @section -- Pod
+tolerations: []

--- a/scripts/oci-push-all.sh
+++ b/scripts/oci-push-all.sh
@@ -18,6 +18,7 @@ CHARTS=(
   lago-data-worker
   lago-data-forecasted-usage
   lago-data-rev-rec
+  lago-data-superset
   lago-mcp-server
   lago-pdf
   lago-data


### PR DESCRIPTION
Ports `lago-superset` from `lago-infrastructure` as a standalone `charts/lago-data-superset/` chart, restructured to repo conventions.

**Design summary:**
- Two Deployments: `web` (`run.py api`, port 8088, health probes) and `worker` (`run.py worker`)
- Machinery image (`image.*`) and assets image (`assets.*`) are separate required values — no baked-in ECR defaults
- A `stage-assets` init-container copies the assets image's `/assets` tree into a shared emptyDir, mounted read-only at `/assets` on both pods
- All environment config flows through `extraEnv` / `extraEnvFrom` — no typed `SUPERSET_*` or `LAGO_*` values in the chart
- Service is ClusterIP → port 8088 (web only); HTTPRoute is out of scope, supplied by the caller
- No hardcoded ArgoCD/external-dns annotations
- Wired into `release.sh` and `oci-push-all.sh` (after `lago-data-rev-rec`)

**Verified:** `helm lint` passes, `helm template` renders both deployments correctly, `required` guards fire on missing image repo/tag.