### PR TITLE
feat(charts): support per-component Sentry DSNs + SENTRY_ENVIRONMENT

### DIFF
--- a/charts/lago-config/templates/configmap.yaml
+++ b/charts/lago-config/templates/configmap.yaml
@@ -51,4 +51,7 @@ data:
   {{- if .Values.global.data.enabled }}
   data.endpoint: {{ required "global.data.endpoint is required" .Values.global.data.endpoint }}
   {{- end }}
+  {{- with .Values.global.sentry.environment }}
+  sentry.environment: {{ . | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/lago-config/templates/secret.yaml
+++ b/charts/lago-config/templates/secret.yaml
@@ -33,8 +33,10 @@ data:
   {{- with .Values.global.lago.license }}
   lago.license: {{ . | b64enc }}
   {{- end }}
-  {{- with .Values.global.sentryDsn }}
-  sentryDsn: {{ . | b64enc }}
+  {{- range $name, $dsn := .Values.global.sentry.dsn }}
+  {{- if $dsn }}
+  sentry.dsn.{{ $name }}: {{ $dsn | b64enc }}
+  {{- end }}
   {{- end }}
   {{- with .Values.global.segmentWriteKey }}
   segmentWriteKey: {{ . | b64enc }}

--- a/charts/lago-config/tests/configmap_test.yaml
+++ b/charts/lago-config/tests/configmap_test.yaml
@@ -119,3 +119,27 @@ tests:
           count: 1
       - isKind:
           of: ConfigMap
+
+  - it: should emit sentry.environment when set
+    set:
+      global.urls.api: "http://api.test"
+      global.urls.front: "http://front.test"
+      global.redis.uri: "redis://localhost"
+      global.redisCache.uri: "redis://localhost"
+      global.redisStore.uri: "redis://localhost"
+      global.sentry.environment: "production"
+    asserts:
+      - equal:
+          path: data["sentry.environment"]
+          value: "production"
+
+  - it: should omit sentry.environment when unset
+    set:
+      global.urls.api: "http://api.test"
+      global.urls.front: "http://front.test"
+      global.redis.uri: "redis://localhost"
+      global.redisCache.uri: "redis://localhost"
+      global.redisStore.uri: "redis://localhost"
+    asserts:
+      - notExists:
+          path: data["sentry.environment"]

--- a/charts/lago-config/tests/secret_test.yaml
+++ b/charts/lago-config/tests/secret_test.yaml
@@ -113,3 +113,61 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should emit a per-component sentry DSN key for each non-empty entry
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+      global.sentry.dsn.back: "https://back@sentry.example/1"
+      global.sentry.dsn.events: "https://events@sentry.example/3"
+      global.sentry.dsn.front: "https://front@sentry.example/2"
+    asserts:
+      - equal:
+          path: data["sentry.dsn.back"]
+          value: "aHR0cHM6Ly9iYWNrQHNlbnRyeS5leGFtcGxlLzE="
+      - equal:
+          path: data["sentry.dsn.events"]
+          value: "aHR0cHM6Ly9ldmVudHNAc2VudHJ5LmV4YW1wbGUvMw=="
+      - equal:
+          path: data["sentry.dsn.front"]
+          value: "aHR0cHM6Ly9mcm9udEBzZW50cnkuZXhhbXBsZS8y"
+
+  - it: should omit sentry DSN keys when all entries are empty
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+    asserts:
+      - notExists:
+          path: data["sentry.dsn.back"]
+      - notExists:
+          path: data["sentry.dsn.events"]
+      - notExists:
+          path: data["sentry.dsn.front"]
+
+  - it: should emit only the populated sentry DSN entries
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+      global.sentry.dsn.back: "https://back@sentry.example/1"
+      global.sentry.dsn.events: ""
+      global.sentry.dsn.front: ""
+    asserts:
+      - equal:
+          path: data["sentry.dsn.back"]
+          value: "aHR0cHM6Ly9iYWNrQHNlbnRyeS5leGFtcGxlLzE="
+      - notExists:
+          path: data["sentry.dsn.events"]
+      - notExists:
+          path: data["sentry.dsn.front"]

--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -112,9 +112,24 @@ global:
     # @section -- Redis
     password: ""
 
-  # -- Sentry DSN for error tracking
-  # @section -- Observability
-  sentryDsn: ""
+  # One DSN per Sentry project. Components that report to the same Sentry
+  # project share a key so fingerprints, traces and release tracking line
+  # up. Add a new entry when a component is run as its own Sentry project
+  # (different SDK or operationally separate service).
+  sentry:
+    dsn:
+      # -- Sentry DSN for the Ruby backend / Sidekiq workers (lago-rails)
+      # @section -- Observability
+      back: ""
+      # -- Sentry DSN for the events processor worker (separate Sentry project from `back`)
+      # @section -- Observability
+      events: ""
+      # -- Sentry DSN for the JavaScript frontend (lago-front)
+      # @section -- Observability
+      front: ""
+      # Future component DSNs plug in as additional map entries:
+      # data: ""
+
   # -- Segment write key for analytics
   # @section -- Observability
   segmentWriteKey: ""

--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -117,6 +117,9 @@ global:
   # up. Add a new entry when a component is run as its own Sentry project
   # (different SDK or operationally separate service).
   sentry:
+    # -- Sentry environment name (e.g. "production", "staging"), injected as SENTRY_ENVIRONMENT into every component that reports to Sentry
+    # @section -- Observability
+    environment: ""
     dsn:
       # -- Sentry DSN for the Ruby backend / Sidekiq workers (lago-rails)
       # @section -- Observability

--- a/charts/lago-data/values.yaml
+++ b/charts/lago-data/values.yaml
@@ -76,10 +76,6 @@ global:
     # @section -- Redis
     password: ""
 
-  # -- Sentry DSN for error tracking
-  # @section -- Observability
-  sentryDsn: ""
-
   databaseAnalytical:
     # -- Analytical database host
     # @section -- Analytical Database

--- a/charts/lago-events-processor-worker/templates/deployment.yaml
+++ b/charts/lago-events-processor-worker/templates/deployment.yaml
@@ -93,6 +93,12 @@ spec:
                   name: {{ include "lago-events-processor-worker.secretName" . }}
                   key: sentry.dsn.events
                   optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lago-events-processor-worker.configMapName" . }}
+                  key: sentry.environment
+                  optional: true
             {{- range $name, $val := .Values.extraEnv }}
             {{- if kindIs "map" $val }}
             - name: {{ $name }}

--- a/charts/lago-events-processor-worker/templates/deployment.yaml
+++ b/charts/lago-events-processor-worker/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago-events-processor-worker.secretName" . }}
-                  key: sentryDsn
+                  key: sentry.dsn.events
                   optional: true
             {{- range $name, $val := .Values.extraEnv }}
             {{- if kindIs "map" $val }}

--- a/charts/lago-events-processor-worker/values.yaml
+++ b/charts/lago-events-processor-worker/values.yaml
@@ -40,6 +40,9 @@ global:
     password: ""
 
   sentry:
+    # -- Sentry environment name (e.g. "production", "staging"), injected as SENTRY_ENVIRONMENT
+    # @section -- Observability
+    environment: ""
     dsn:
       # -- Sentry DSN for the events processor worker (separate Sentry project from lago-rails)
       # @section -- Observability

--- a/charts/lago-events-processor-worker/values.yaml
+++ b/charts/lago-events-processor-worker/values.yaml
@@ -39,6 +39,12 @@ global:
     # @section -- Redis
     password: ""
 
+  sentry:
+    dsn:
+      # -- Sentry DSN for the events processor worker (separate Sentry project from lago-rails)
+      # @section -- Observability
+      events: ""
+
   streaming_ingestion:
     # -- Enable streaming ingestion (ClickHouse + Kafka)
     # @section -- Streaming Ingestion

--- a/charts/lago-front/templates/deployment.yaml
+++ b/charts/lago-front/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago-front.secretName" . }}
-                  key: sentryDsn
+                  key: sentry.dsn.front
                   optional: true
             - name: LAGO_DISABLE_SIGNUP
               value: {{ not .Values.global.lago.signup | quote }}

--- a/charts/lago-front/templates/deployment.yaml
+++ b/charts/lago-front/templates/deployment.yaml
@@ -67,6 +67,12 @@ spec:
                   name: {{ include "lago-front.secretName" . }}
                   key: sentry.dsn.front
                   optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lago-front.configMapName" . }}
+                  key: sentry.environment
+                  optional: true
             - name: LAGO_DISABLE_SIGNUP
               value: {{ not .Values.global.lago.signup | quote }}
             {{- if .Values.global.gocardless.enabled }}

--- a/charts/lago-front/values.yaml
+++ b/charts/lago-front/values.yaml
@@ -30,6 +30,9 @@ global:
     publicKey: ""
 
   sentry:
+    # -- Sentry environment name (e.g. "production", "staging"), injected as SENTRY_ENVIRONMENT
+    # @section -- Observability
+    environment: ""
     dsn:
       # -- Sentry DSN for the frontend
       # @section -- Observability

--- a/charts/lago-front/values.yaml
+++ b/charts/lago-front/values.yaml
@@ -29,9 +29,11 @@ global:
     # @section -- Nango
     publicKey: ""
 
-  # -- Sentry DSN for error tracking
-  # @section -- Observability
-  sentryDsn: ""
+  sentry:
+    dsn:
+      # -- Sentry DSN for the frontend
+      # @section -- Observability
+      front: ""
 
   gocardless:
     # -- Enable GoCardless integration

--- a/charts/lago-pdf/values.yaml
+++ b/charts/lago-pdf/values.yaml
@@ -110,9 +110,6 @@ global:
     # @section -- Redis
     password: ""
 
-  # -- Sentry DSN for error tracking
-  # @section -- Observability
-  sentryDsn: ""
   # -- Segment write key for analytics
   # @section -- Observability
   segmentWriteKey: ""

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago-rails.secretName" . }}
-                  key: sentryDsn
+                  key: sentry.dsn.back
                   optional: true
             - name: SEGMENT_WRITE_KEY
               valueFrom:

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -153,6 +153,12 @@ spec:
                   name: {{ include "lago-rails.secretName" . }}
                   key: sentry.dsn.back
                   optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lago-rails.configMapName" . }}
+                  key: sentry.environment
+                  optional: true
             - name: SEGMENT_WRITE_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -110,9 +110,12 @@ global:
     # @section -- Redis
     password: ""
 
-  # -- Sentry DSN for error tracking
-  # @section -- Observability
-  sentryDsn: ""
+  sentry:
+    dsn:
+      # -- Sentry DSN for the backend (lago-rails and lago-events-processor-worker share this DSN)
+      # @section -- Observability
+      back: ""
+
   # -- Segment write key for analytics
   # @section -- Observability
   segmentWriteKey: ""

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -111,6 +111,9 @@ global:
     password: ""
 
   sentry:
+    # -- Sentry environment name (e.g. "production", "staging"), injected as SENTRY_ENVIRONMENT
+    # @section -- Observability
+    environment: ""
     dsn:
       # -- Sentry DSN for the backend (lago-rails and lago-events-processor-worker share this DSN)
       # @section -- Observability

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -120,6 +120,9 @@ global:
   # up. Add a new entry when a component is run as its own Sentry project
   # (different SDK or operationally separate service).
   sentry:
+    # -- Sentry environment name (e.g. "production", "staging"), injected as SENTRY_ENVIRONMENT into every component that reports to Sentry
+    # @section -- Observability
+    environment: ""
     dsn:
       # -- Sentry DSN for the Ruby backend / Sidekiq workers (lago-rails)
       # @section -- Observability

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -115,9 +115,24 @@ global:
     # @section -- Redis
     password: ""
 
-  # -- Sentry DSN for error tracking
-  # @section -- Observability
-  sentryDsn: ""
+  # One DSN per Sentry project. Components that report to the same Sentry
+  # project share a key so fingerprints, traces and release tracking line
+  # up. Add a new entry when a component is run as its own Sentry project
+  # (different SDK or operationally separate service).
+  sentry:
+    dsn:
+      # -- Sentry DSN for the Ruby backend / Sidekiq workers (lago-rails)
+      # @section -- Observability
+      back: ""
+      # -- Sentry DSN for the events processor worker (separate Sentry project from `back`)
+      # @section -- Observability
+      events: ""
+      # -- Sentry DSN for the JavaScript frontend (lago-front)
+      # @section -- Observability
+      front: ""
+      # Future component DSNs plug in as additional map entries:
+      # data: ""
+
   # -- Segment write key for analytics
   # @section -- Observability
   segmentWriteKey: ""


### PR DESCRIPTION
## Summary

- Replace the single `global.sentryDsn` with a map `global.sentry.dsn` keyed by Sentry project. `lago-rails` uses `global.sentry.dsn.back`; `lago-events-processor-worker` uses `global.sentry.dsn.events` (a separate Sentry project in production); `lago-front` uses `global.sentry.dsn.front`.
- The `lago-config` secret ranges the map and emits one `sentry.dsn.<name>` entry per non-empty DSN — adding a future component (data stack, etc.) is a one-line values addition, no template change.
- Add `global.sentry.environment`, emitted as `sentry.environment` in the `lago-config` ConfigMap and wired as `SENTRY_ENVIRONMENT` alongside `SENTRY_DSN` in `lago-rails`, `lago-events-processor-worker`, and `lago-front`. Single string applied uniformly to every Sentry-reporting component (the [SDK option](https://docs.sentry.io/platforms/ruby/configuration/options/#environment) is the same name and meaning across Ruby/JS). ConfigMap key is `optional: true`, so leaving the value unset omits the env var entirely.
- Drop the unused `global.sentryDsn` declarations from `lago-pdf` and `lago-data` (declared but never wired into a template).

## Why

Today every chart pulls the same DSN, but the production setup uses three distinct Sentry projects: one for the Rails monolith + its Sidekiq workers, one for the events processor (separate codebase, separate alert rules), and one for the JS frontend. The scalar schema can't express that. Separately, callers need to tag events with the deploy environment (`production`, `staging`, …) so Sentry can scope alert rules and release tracking — the standard mechanism is the `SENTRY_ENVIRONMENT` env var, which was not being injected.

## Design rationale: one DSN per Sentry project

The rule that decides whether a component gets its own DSN entry is **separate Sentry project**, which in practice means either a different SDK or operationally separate ownership:

- **Same project → same DSN.** `lago-rails` covers Sidekiq, clock, and the API web tier — all run the same Ruby SDK against the same Sentry project, so they share `back`. Fingerprints and traces link across them; splitting would multiply alert rules and fragment release tracking.
- **Different project → separate DSN.** `lago-events-processor-worker` is a distinct service with its own Sentry project (confirmed against prod-us and prod-eu). Hence `events`.
- **Different SDK → separate DSN.** `lago-front` uses the JS SDK with source maps and a different stack-frame shape than Ruby. Hence `front`.
- **Future entries** (e.g. `data`) plug in as additional map entries when a new SDK or service is introduced.

`SENTRY_ENVIRONMENT` is the orthogonal axis: same value across every component (cluster/environment separation), tags inside each project rather than additional DSNs.

## Migration

Breaking change to the public values schema. Callers must move from:

```yaml
global:
  sentryDsn: "https://..."
```

to:

```yaml
global:
  sentry:
    environment: "production"  # optional, e.g. "production" / "staging"
    dsn:
      back: "https://..."    # lago-rails (Ruby SDK, Sidekiq + API + clock)
      events: "https://..."  # lago-events-processor-worker (separate Sentry project)
      front: "https://..."   # lago-front (JS SDK)
```

## Test plan

- [x] `task test:unit` — all suites pass (lago-config gains 3 updated secret tests covering `back`/`events`/`front` map emission, and 2 new configmap tests for `sentry.environment` emit/omit)
- [x] `ct lint --all` — clean
- [x] `helm template ./charts/lago -f charts/lago/examples/basic_workers.yaml -f charts/lago/examples/streaming_ingestion.yaml --set global.sentry.dsn.back=... --set global.sentry.dsn.events=... --set global.sentry.dsn.front=... --set global.sentry.environment=production` — confirmed per-deployment DSN binding: `events-processor-worker` → `sentry.dsn.events`, `front` → `sentry.dsn.front`, every other deployment (api, billing-worker, clock, clock-worker, events-consumer-worker, events-worker, pdf-worker, webhook-worker, worker) → `sentry.dsn.back`; all three pull `SENTRY_ENVIRONMENT` from the ConfigMap
- [x] Render with nothing set — Secret emits no `sentry.dsn.*` key, ConfigMap emits no `sentry.environment` key, and the `optional: true` references degrade to "env var not set" at runtime

## Out of scope

- `README.md` regeneration via `helm-docs` — would pull in unrelated pre-existing drift (chart version refs, annotation reordering) across many charts. Best done as its own pass.