### PR TITLE
feat(charts): make HTTPRoute backendRefs optional per rule

### DIFF
--- a/charts/lago-front/templates/httproute.yaml
+++ b/charts/lago-front/templates/httproute.yaml
@@ -38,11 +38,18 @@ spec:
       filters:
       {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if hasKey . "backendRefs" }}
+      {{- with .backendRefs }}
+      backendRefs:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- else }}
       backendRefs:
         - group: ""
           kind: Service
           name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/lago-rails/templates/httproute.yaml
+++ b/charts/lago-rails/templates/httproute.yaml
@@ -38,11 +38,18 @@ spec:
       filters:
       {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if hasKey . "backendRefs" }}
+      {{- with .backendRefs }}
+      backendRefs:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- else }}
       backendRefs:
         - group: ""
           kind: Service
           name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
+    {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

`lago-rails` and `lago-front` always appended the default service `backendRefs` to every rule in their `HTTPRoute` template. That blocked rules ending in a terminal filter (`DirectResponse` via `ExtensionRef`, `RequestRedirect`, etc.), since those must render *without* a `backendRefs` to be valid Gateway API.

The change uses `hasKey` on `.backendRefs` per rule:

- omitted → default service backend injected (back-compat with every existing values file)
- `backendRefs: []` → no `backendRefs` rendered, for terminal-filter rules
- explicit list → passed through for custom or weighted backends

`HTTPRouteRule.backendRefs` is optional in the Gateway API spec, so this just stops the chart from overriding that optionality.

Motivation: `lago-infrastructure` needs to add a `/metrics` block rule (DirectResponse 404 via Envoy Gateway's `HTTPRouteFilter`) to the `lago-api` HTTPRoute in staging-eu. Since that route is templated by `lago-rails`, the chart had to grow a hook for terminal filters.

## Test plan

- [x] `helm template charts/lago-rails -f <values>` with `backendRefs: []` on a rule renders the rule with no `backendRefs:` line
- [x] same with `backendRefs: [{...}]` renders the user backends
- [x] same with no `backendRefs` key renders the default service backend (back-compat)
- [x] same three cases on `charts/lago-front`
- [x] `task render` on the umbrella `lago` chart exits clean
- [ ] (deferred) `task test:unit` once `untt` is available locally