### PR TITLE
fix(lago-data-superset): loosen web probe timeouts

### DIFF
--- a/charts/lago-data-superset/values.yaml
+++ b/charts/lago-data-superset/values.yaml
@@ -71,13 +71,15 @@ web:
   # -- Web container resources
   # @section -- Web
   resources: {}
-  # -- Web startup probe (boot runs migrations + bundle import, so allow a generous window)
+  # -- Web startup probe (boot runs db upgrade + bundle import; budget covers slow metadata DB)
   # @section -- Web
   startupProbe:
     httpGet:
       path: /health
       port: http
+    initialDelaySeconds: 15
     periodSeconds: 10
+    timeoutSeconds: 5
     failureThreshold: 60
   # -- Web liveness probe
   # @section -- Web
@@ -85,14 +87,20 @@ web:
     httpGet:
       path: /health
       port: http
-    periodSeconds: 15
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
   # -- Web readiness probe
   # @section -- Web
   readinessProbe:
     httpGet:
       path: /health
       port: http
-    periodSeconds: 15
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
 
 worker:
   # -- Celery worker replica count


### PR DESCRIPTION
Bakes in the probe settings validated in lago-infrastructure#1084, where the web container was restart-looping on prod under embedded-dashboard burst traffic.

**Root cause:** default `timeoutSeconds: 1` caused `/health` to time out under load, triggering liveness kills mid-flight. Startup probe budget was also too tight when `superset db upgrade` runs against a slow metadata DB.

**New defaults:**

| Probe | Field | Before | After |
|---|---|---|---|
| `startupProbe` | `timeoutSeconds` | 1 (K8s default) | 5 |
| | `initialDelaySeconds` | — | 15 |
| | `failureThreshold` | 60 (~5 min) | 60 (~10 min) |
| `livenessProbe` | `timeoutSeconds` | 1 (K8s default) | 5 |
| | `periodSeconds` | 15 | 30 |
| | `failureThreshold` | 3 (K8s default) | 5 |
| | `initialDelaySeconds` | — | 15 |
| `readinessProbe` | same as liveness | | |

Worker probes are untouched.