### PR TITLE
feat(rails): expose global.database.preparedStatement

### DIFF
--- a/charts/lago-config/README.md
+++ b/charts/lago-config/README.md
@@ -50,6 +50,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | global.database.uri | string | `""` | PostgreSQL connection URI |
 | global.database.pool | int | `20` | Database connection pool size |
+| global.database.preparedStatement | bool | `nil` | Enable ActiveRecord prepared statements. Leave unset to use the Rails default (`true`); set to `false` when running behind a connection pooler that can't multiplex sessions issuing prepared statements. Renders the `DATABASE_PREPARED_STATEMENTS` env var on Rails pods only when explicitly set. |
 
 ### Encryption
 

--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -71,6 +71,13 @@ global:
     # -- Database connection pool size
     # @section -- Database
     pool: 20
+    # -- (bool) Enable ActiveRecord prepared statements. Leave unset to use the
+    # Rails default (`true`); set to `false` when running behind a connection
+    # pooler that can't multiplex sessions issuing prepared statements. Renders
+    # the `DATABASE_PREPARED_STATEMENTS` env var on Rails pods only when
+    # explicitly set.
+    # @section -- Database
+    preparedStatement:
 
   encryption:
     # -- Primary encryption key (`openssl rand -hex 16`)

--- a/charts/lago-rails/README.md
+++ b/charts/lago-rails/README.md
@@ -22,6 +22,7 @@ A Helm chart for Kubernetes
 | config.log.level | string | `"info"` | Log level (`debug`, `info`, `warn`, `error`) |
 | config.log.stdout | bool | `true` | Log to stdout |
 | config.database.pool | int | `nil` | Override the global database pool size for this instance |
+| config.database.preparedStatement | bool | `nil` | Override `global.database.preparedStatement` for this instance |
 | config.otel.enabled | bool | `false` | Enable OpenTelemetry tracing |
 | config.otel.endpoint | string | `nil` | OpenTelemetry collector endpoint |
 | config.otel.serviceName | string | `nil` | OpenTelemetry service name |

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -61,6 +61,15 @@ spec:
               value: {{ .Values.config.log.stdout | quote }}
             - name: DATABASE_POOL
               value: {{ default .Values.global.database.pool .Values.config.database.pool | quote }}
+            {{/* Per-instance override wins over the umbrella default. */}}
+            {{- if kindIs "bool" .Values.config.database.preparedStatement }}
+            - name: DATABASE_PREPARED_STATEMENTS
+              value: {{ .Values.config.database.preparedStatement | quote }}
+            {{/* Fall back to the global value shared across every Rails pod. */}}
+            {{- else if kindIs "bool" .Values.global.database.preparedStatement }}
+            - name: DATABASE_PREPARED_STATEMENTS
+              value: {{ .Values.global.database.preparedStatement | quote }}
+            {{- end }}
             - name: LAGO_SIDEKIQ_PRO_REQUIRED
               value: {{ .Values.global.sidekiq.pro | quote }}
             - name: LAGO_SIDEKIQ_WEB

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -69,6 +69,13 @@ global:
     # -- Database connection pool size
     # @section -- Database
     pool: 20
+    # -- (bool) Enable ActiveRecord prepared statements. Leave unset to use the
+    # Rails default (`true`); set to `false` when running behind a connection
+    # pooler that can't multiplex sessions issuing prepared statements. Renders
+    # the `DATABASE_PREPARED_STATEMENTS` env var on Rails pods only when
+    # explicitly set.
+    # @section -- Database
+    preparedStatement:
 
   encryption:
     # -- Primary encryption key (`openssl rand -hex 16`)
@@ -320,6 +327,9 @@ config:
     # -- (int) Override the global database pool size for this instance
     # @section -- Config
     pool:
+    # -- (bool) Override `global.database.preparedStatement` for this instance
+    # @section -- Config
+    preparedStatement:
 
   otel:
     # -- Enable OpenTelemetry tracing

--- a/charts/lago/README.md
+++ b/charts/lago/README.md
@@ -236,6 +236,7 @@ A Helm chart for Kubernetes
 | migrate.config.log.level | string | `"info"` | Log level (`debug`, `info`, `warn`, `error`) |
 | migrate.config.log.stdout | bool | `true` | Log to stdout |
 | migrate.config.database.pool | int | `nil` | Override the global database pool size for this instance |
+| migrate.config.database.preparedStatement | bool | `nil` | Override `global.database.preparedStatement` for this instance |
 
 ### Create Topics Job
 

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -65,6 +65,15 @@ spec:
               value: {{ default .Values.global.lago.env .Values.migrate.config.env }}
             - name: DATABASE_POOL
               value: {{ default .Values.global.database.pool .Values.migrate.config.database.pool | quote }}
+            {{/* Per-instance override wins over the umbrella default. */}}
+            {{- if kindIs "bool" .Values.migrate.config.database.preparedStatement }}
+            - name: DATABASE_PREPARED_STATEMENTS
+              value: {{ .Values.migrate.config.database.preparedStatement | quote }}
+            {{/* Fall back to the global value shared across every Rails pod. */}}
+            {{- else if kindIs "bool" .Values.global.database.preparedStatement }}
+            - name: DATABASE_PREPARED_STATEMENTS
+              value: {{ .Values.global.database.preparedStatement | quote }}
+            {{- end }}
             - name: LAGO_LOG_LEVEL
               value: {{ .Values.migrate.config.log.level }}
             - name: RAILS_LOG_TO_STDOUT

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -74,6 +74,13 @@ global:
     # -- Database connection pool size
     # @section -- Database
     pool: 20
+    # -- (bool) Enable ActiveRecord prepared statements. Leave unset to use the
+    # Rails default (`true`); set to `false` when running behind a connection
+    # pooler that can't multiplex sessions issuing prepared statements. Renders
+    # the `DATABASE_PREPARED_STATEMENTS` env var on Rails pods only when
+    # explicitly set.
+    # @section -- Database
+    preparedStatement:
 
   encryption:
     # -- Primary encryption key (`openssl rand -hex 16`)
@@ -705,6 +712,9 @@ migrate:
       # -- (int) Override the global database pool size for this instance
       # @section -- Database Migration / Config
       pool:
+      # -- (bool) Override `global.database.preparedStatement` for this instance
+      # @section -- Database Migration / Config
+      preparedStatement:
   image:
     # -- Migration job image repository
     # @section -- Database Migration


### PR DESCRIPTION
## Summary

Adds an opt-in toggle for ActiveRecord prepared statements, exposed as `global.database.preparedStatement` (default unset). When set, the chart renders `DATABASE_PREPARED_STATEMENTS=<value>` on every Rails container (api / worker / clock / specialized workers) and on the umbrella's migrate Job.

Motivation: some PostgreSQL connection-pooling proxies cannot multiplex sessions that issue prepared statements, which can cause connection pinning and prevents graceful draining. This adds a clean dial to flip it off without overriding the env via `extraEnv` in every subchart.

Per-instance override available at `config.database.preparedStatement` on each `lago-rails` subchart (and at `migrate.config.database.preparedStatement` on the umbrella).

## Behavior

| Values | Effect |
|---|---|
| default (unset) | env var not emitted; Rails uses its default |
| `global.database.preparedStatement: false` | emitted as `"false"` on all Rails pods + migrate job |
| `global: false` + `api.config.database.preparedStatement: true` | api gets `"true"`, everyone else `"false"` |
| only `api.config.database.preparedStatement: false` | only api gets the env var |

The template uses `kindIs "invalid"` to detect nil rather than Helm's `default` helper, so an explicit `false` correctly overrides a `true` global (`default true false` would otherwise return `true`).

## Test plan

- [x] `task lint` — all 15 charts pass
- [x] `helm template lago ./charts/lago -f examples/basic.yaml` with the matrix above — verified env var is emitted/omitted as expected
- [ ] Manual sanity in staging once consumers (`lago-deploy` values) opt in