### PR TITLE
fix(lago-data-api): point probes at /health-check/

### DIFF
--- a/charts/lago-data-api/values.yaml
+++ b/charts/lago-data-api/values.yaml
@@ -203,7 +203,7 @@ resources: {}
 # @section -- Pod
 livenessProbe:
   httpGet:
-    path: /
+    path: /health-check/
     port: http
   initialDelaySeconds: 10
   periodSeconds: 30
@@ -214,7 +214,7 @@ livenessProbe:
 # @section -- Pod
 readinessProbe:
   httpGet:
-    path: /
+    path: /health-check/
     port: http
   initialDelaySeconds: 10
   periodSeconds: 3


### PR DESCRIPTION
## Summary
- The chart defaulted `livenessProbe`/`readinessProbe` to `path: /`, but the FastAPI app in `getlago/lago-data` has no root route — probes were getting 404s (any 4xx = probe failure).
- Point both probes at the actual health endpoint, `/health-check/`, defined in `api/app/routes.py`:
  ```python
  @app.get("/health-check/")
  def health_check() -> bool:
      return True
  ```
- No chart version bump — release pipeline handles that.

## Test plan
- [ ] `task lint` passes
- [ ] `helm template ./charts/lago-data-api` renders with the new probe paths
- [ ] After release + deploy, verify pod probes no longer show 404 in kube events

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)