### PR TITLE
feat(lago-config): declare unprocessed_events topic + fix securityLogs value

### DIFF
--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -323,7 +323,10 @@ global:
         apiLogs: api_logs
         # -- Kafka topic for security logs
         # @section -- Streaming Ingestion / Kafka
-        securityLogs: securityLogs
+        securityLogs: security_logs
+        # -- Kafka topic for unprocessed events (dead-letter for pre-enrichment failures)
+        # @section -- Streaming Ingestion / Kafka
+        unprocessedEvents: unprocessed_events
 
 configmap:
   # -- Create the ConfigMap (set to false when using an externally managed ConfigMap)


### PR DESCRIPTION
## Summary

Two small changes to `global.streaming_ingestion.kafka.topics` in lago-config:

1. **Add \`unprocessedEvents: unprocessed_events\`.** The topic already exists on the prod-us Redpanda cluster and is now managed by Pulumi across staging-eu-1 (and eventually the prod stacks) via [lago-infrastructure/pulumi/projects/lago](https://github.com/getlago/lago-infrastructure/blob/main/pulumi/projects/lago/src/resources/lagoRedpandaTopics.ts). Declaring the key here lets the app config map the topic name and unblocks lago-infrastructure PR #1137 (which validates every Pulumi topic against the chart's declared key set).
2. **Fix \`securityLogs: securityLogs\`.** The value should be the snake_case Kafka topic name \`security_logs\`, matching every other entry in this block and the actual topic in Redpanda.

## Test plan

- [ ] `helm template` a chart install with `global.streaming_ingestion.enabled=true` and confirm the rendered ConfigMap / env vars carry `LAGO_KAFKA_TOPIC_UNPROCESSED_EVENTS=unprocessed_events` and `LAGO_KAFKA_TOPIC_SECURITY_LOGS=security_logs`.