### PR TITLE
feat(charts): make S3 credentials optional to support pod identity

### DIFF
--- a/charts/lago-config/README.md
+++ b/charts/lago-config/README.md
@@ -96,8 +96,8 @@ A Helm chart for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.s3.enabled | bool | `false` | Enable S3-compatible object storage |
-| global.s3.accessKeyId | string | `""` | S3 access key ID |
-| global.s3.secretAccessKey | string | `""` | S3 secret access key |
+| global.s3.accessKeyId | string | `""` | S3 access key ID. Leave empty to authenticate via IRSA / EKS Pod Identity. |
+| global.s3.secretAccessKey | string | `""` | S3 secret access key. Leave empty to authenticate via IRSA / EKS Pod Identity. |
 | global.s3.bucket | string | `""` | S3 bucket name |
 | global.s3.region | string | `""` | S3 region |
 | global.s3.endpoint | string | `""` | S3 custom endpoint (for MinIO, etc.) |

--- a/charts/lago-config/templates/secret.yaml
+++ b/charts/lago-config/templates/secret.yaml
@@ -56,8 +56,12 @@ data:
   gocardless.clientSecret: {{ required "global.gocardless.clientSecret is required" .Values.global.gocardless.clientSecret | b64enc }}
   {{- end }}
   {{- if .Values.global.s3.enabled }}
-  s3.accessKeyId: {{ required "global.s3.accessKeyId is required" .Values.global.s3.accessKeyId | b64enc }}
-  s3.secretAccessKey: {{ required "global.s3.secretAccessKey is required" .Values.global.s3.secretAccessKey | b64enc }}
+  {{- with .Values.global.s3.accessKeyId }}
+  s3.accessKeyId: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.global.s3.secretAccessKey }}
+  s3.secretAccessKey: {{ . | b64enc }}
+  {{- end }}
   {{- end }}
   {{- if .Values.global.mcp.enabled }}
   mcp.clientId: {{ required "global.mcp.clientId is required" .Values.global.mcp.clientId | b64enc }}

--- a/charts/lago-config/tests/secret_test.yaml
+++ b/charts/lago-config/tests/secret_test.yaml
@@ -171,3 +171,72 @@ tests:
           path: data["sentry.dsn.events"]
       - notExists:
           path: data["sentry.dsn.front"]
+
+  - it: should emit s3 credential keys when both are set
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+      global.s3.enabled: true
+      global.s3.accessKeyId: "AKIAEXAMPLE"
+      global.s3.secretAccessKey: "secretvalue"
+    asserts:
+      - equal:
+          path: data["s3.accessKeyId"]
+          value: "QUtJQUVYQU1QTEU="
+      - equal:
+          path: data["s3.secretAccessKey"]
+          value: "c2VjcmV0dmFsdWU="
+
+  - it: should omit s3 credential keys when s3 is enabled but no keys are set (pod identity)
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+      global.s3.enabled: true
+    asserts:
+      - notExists:
+          path: data["s3.accessKeyId"]
+      - notExists:
+          path: data["s3.secretAccessKey"]
+
+  - it: should emit only the populated s3 credential when one is empty
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+      global.s3.enabled: true
+      global.s3.accessKeyId: "AKIAEXAMPLE"
+      global.s3.secretAccessKey: ""
+    asserts:
+      - equal:
+          path: data["s3.accessKeyId"]
+          value: "QUtJQUVYQU1QTEU="
+      - notExists:
+          path: data["s3.secretAccessKey"]
+
+  - it: should omit s3 credential keys when s3 is disabled
+    set:
+      secret.create: true
+      global.database.uri: "postgresql://localhost"
+      global.encryption.key: "test-key"
+      global.encryption.salt: "test-salt"
+      global.signing.hmac: "test-hmac"
+      global.signing.rsa: "test-rsa"
+      global.s3.enabled: false
+      global.s3.accessKeyId: "AKIAEXAMPLE"
+      global.s3.secretAccessKey: "secretvalue"
+    asserts:
+      - notExists:
+          path: data["s3.accessKeyId"]
+      - notExists:
+          path: data["s3.secretAccessKey"]

--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -156,10 +156,10 @@ global:
     # -- Enable S3-compatible object storage
     # @section -- S3
     enabled: false
-    # -- S3 access key ID
+    # -- S3 access key ID. Leave empty to authenticate via IRSA / EKS Pod Identity.
     # @section -- S3
     accessKeyId: ""
-    # -- S3 secret access key
+    # -- S3 secret access key. Leave empty to authenticate via IRSA / EKS Pod Identity.
     # @section -- S3
     secretAccessKey: ""
     # -- S3 bucket name

--- a/charts/lago-data-forecasted-usage/README.md
+++ b/charts/lago-data-forecasted-usage/README.md
@@ -37,8 +37,8 @@ A Helm chart for Kubernetes
 | config.nameOverride | string | `"lago-data-forecasted-usage"` | Override the config subchart release name |
 | config.s3.secret.create | bool | `true` | Create the S3 credentials secret |
 | config.s3.secret.name | string | `nil` | Use an existing S3 secret by name |
-| config.s3.accessKeyId | string | `nil` | S3 access key ID for model storage |
-| config.s3.secretAccessKey | string | `nil` | S3 secret access key for model storage |
+| config.s3.accessKeyId | string | `nil` | S3 access key ID for model storage. Leave empty to authenticate via IRSA / EKS Pod Identity. |
+| config.s3.secretAccessKey | string | `nil` | S3 secret access key for model storage. Leave empty to authenticate via IRSA / EKS Pod Identity. |
 | config.ml.secret.create | bool | `true` | Create the ML config secret |
 | config.ml.secret.name | string | `nil` | Use an existing ML secret by name |
 | config.ml.config | string | `""` | ML model configuration (YAML or JSON string) |

--- a/charts/lago-data-forecasted-usage/templates/cronjob.yaml
+++ b/charts/lago-data-forecasted-usage/templates/cronjob.yaml
@@ -96,11 +96,13 @@ spec:
                     secretKeyRef:
                       name: {{ include "lago-data-forecasted-usage.s3.secretName" . }}
                       key: s3.accessKeyId
+                      optional: true
                 - name: AWS_SECRET_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:
                       name: {{ include "lago-data-forecasted-usage.s3.secretName" . }}
                       key: s3.secretAccessKey
+                      optional: true
                 - name: ML_CONFIG_YAML
                   valueFrom:
                     secretKeyRef:

--- a/charts/lago-data-forecasted-usage/templates/secrets/s3.yaml
+++ b/charts/lago-data-forecasted-usage/templates/secrets/s3.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "lago-data-forecasted-usage.labels" . | nindent 4 }}
 type: Opaque
 data:
-  s3.accessKeyId: {{ required "config.s3.accessKeyId value is required" .Values.config.s3.accessKeyId | b64enc }}
-  s3.secretAccessKey: {{ required "config.s3.secretAccessKey value is required" .Values.config.s3.secretAccessKey | b64enc }}
+  {{- with .Values.config.s3.accessKeyId }}
+  s3.accessKeyId: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.config.s3.secretAccessKey }}
+  s3.secretAccessKey: {{ . | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/lago-data-forecasted-usage/values.yaml
+++ b/charts/lago-data-forecasted-usage/values.yaml
@@ -42,10 +42,10 @@ config:
       # -- Use an existing S3 secret by name
       # @section -- Config
       name:
-    # -- S3 access key ID for model storage
+    # -- S3 access key ID for model storage. Leave empty to authenticate via IRSA / EKS Pod Identity.
     # @section -- Config
     accessKeyId:
-    # -- S3 secret access key for model storage
+    # -- S3 secret access key for model storage. Leave empty to authenticate via IRSA / EKS Pod Identity.
     # @section -- Config
     secretAccessKey:
 

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -236,11 +236,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "lago-rails.secretName" . }}
                   key: s3.accessKeyId
+                  optional: true
             - name: LAGO_AWS_S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago-rails.secretName" . }}
                   key: s3.secretAccessKey
+                  optional: true
             {{- end }}
             {{- if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL


### PR DESCRIPTION
## Summary

- Drop the `required` on `global.s3.accessKeyId` / `secretAccessKey` in `lago-config` and the equivalent `config.s3.*` keys in `lago-data-forecasted-usage`. The generated `Secret` now only carries an S3 key when a value is provided, so leaving them blank is a valid configuration.
- Add `optional: true` on the corresponding `secretKeyRef` env entries in the `lago-rails` deployment and the `lago-data-forecasted-usage` cronjob, so the pod starts even when the keys are absent from the `Secret`.

Together this lets clusters authenticate to S3 via IRSA / EKS Pod Identity while keeping the static-key path unchanged for existing deployments.

## Test plan

- [x] `helm unittest charts/lago-config` — 48/48 passing (4 new cases covering: both keys set, both empty w/ `s3.enabled=true`, one empty one set, `s3.enabled=false` with keys still present).
- [x] `helm template` on `lago-config` shows S3 keys omitted from the rendered `Secret` when unset and present (b64-encoded) when set.
- [x] `helm template` on `lago-rails` and `lago-data-forecasted-usage` shows `optional: true` on the S3 `secretKeyRef` env entries.
- [ ] Deploy to a cluster with pod identity configured and confirm the workload boots without static keys.