### PR TITLE
Feat/rails graceful shutdown pdb

### DIFF
--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "lago-rails.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -352,6 +355,10 @@ spec:
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/lago-rails/templates/pdb.yaml
+++ b/charts/lago-rails/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lago-rails.fullname" . }}
+  labels:
+    {{- include "lago-rails.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lago-rails.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/lago-rails/tests/graceful_shutdown_pdb_test.yaml
+++ b/charts/lago-rails/tests/graceful_shutdown_pdb_test.yaml
@@ -1,0 +1,100 @@
+suite: Test graceful shutdown and PodDisruptionBudget
+templates:
+  - templates/deployment.yaml
+  - templates/pdb.yaml
+values:
+  - ../values.yaml
+
+tests:
+  # ============================================================================
+  # terminationGracePeriodSeconds
+  # ============================================================================
+  - it: should set terminationGracePeriodSeconds when specified
+    template: templates/deployment.yaml
+    values:
+      - ./fixtures/required.yaml
+    set:
+      terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+
+  - it: should not set terminationGracePeriodSeconds by default
+    template: templates/deployment.yaml
+    values:
+      - ./fixtures/required.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+
+  # ============================================================================
+  # lifecycle / preStop
+  # ============================================================================
+  - it: should render preStop lifecycle hook when specified
+    template: templates/deployment.yaml
+    values:
+      - ./fixtures/required.yaml
+    set:
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sleep", "15"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sleep", "15"]
+
+  - it: should not render lifecycle by default
+    template: templates/deployment.yaml
+    values:
+      - ./fixtures/required.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+
+  # ============================================================================
+  # PodDisruptionBudget
+  # ============================================================================
+  - it: should not render a PDB by default
+    template: templates/pdb.yaml
+    values:
+      - ./fixtures/required.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a PDB with maxUnavailable when enabled
+    template: templates/pdb.yaml
+    values:
+      - ./fixtures/required.yaml
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should render a PDB with minAvailable when set
+    template: templates/pdb.yaml
+    values:
+      - ./fixtures/required.yaml
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        maxUnavailable: null
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -576,6 +576,18 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 1
 
+# -- (int) Pod termination grace period (seconds). Unset uses the K8s default (30)
+# @section -- Pod
+terminationGracePeriodSeconds:
+
+# -- Container lifecycle hooks (e.g. a preStop sleep to drain connections on shutdown)
+# @default -- `{}`
+# @section -- Pod
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sleep", "15"]
+
 autoscaling:
   # -- Enable Horizontal Pod Autoscaler
   # @section -- Autoscaling
@@ -593,6 +605,17 @@ autoscaling:
   # @section -- Autoscaling
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  # -- Create a PodDisruptionBudget. Only enable on multi-replica deployments
+  # @section -- Pod Disruption Budget
+  enabled: false
+  # -- (int/string) Minimum pods that must stay available (mutually exclusive with maxUnavailable)
+  # @section -- Pod Disruption Budget
+  minAvailable:
+  # -- (int/string) Maximum pods that may be unavailable during disruption
+  # @section -- Pod Disruption Budget
+  maxUnavailable: 1
 
 # -- Additional volumes
 # @section -- Pod


### PR DESCRIPTION
  What

  Adds three opt-in, values-gated fields to the lago-rails chart (aliased as api and all workers) to harden pods against involuntary disruption during Karpenter node consolidation and EKS upgrades:

  - terminationGracePeriodSeconds (pod spec)
  - lifecycle (container) — for a preStop sleep
  - podDisruptionBudget — new pdb.yaml template with minAvailable / maxUnavailable

  Why

  During node drains, SIGTERM to Puma and EndpointSlice removal race, so the gateway keeps routing to a terminating pod → brief 502/503s. A preStop sleep keeps the pod serving until it's removed from the gateway's endpoints, and a PDB caps how many pods drain at once. This is the first iteration of hardening we'll roll to staging-eu-1 then prod-eu-1.

  Notes for reviewers

  - Fully backward-compatible — all three default off/empty, so existing consumers render identically.
  - PDB single-replica trap: a PDB on a 1-replica Deployment wedges node drain. Enablement is per-alias via values; we'll only turn it on for the multi-replica api (done in the lago-deploy PR), never blindly on workers.
  - Chart.yaml/Chart.lock intentionally untouched — the release pipeline owns version bumps.
  - Enabling these in staging-eu-1 / prod-eu-1 (plus the Envoy BackendTrafficPolicy retries) is a separate lago-deploy PR.

  Testing

  - helm lint clean; 16/16 helm-unittest cases pass (new graceful_shutdown_pdb_test.yaml covers all three, both on and off).
  - Verified rendered output for lago-rails and the umbrella lago chart.