### PR TITLE
refactor(lago-rails): list-based ports + customProbe escape hatch

### DIFF
--- a/charts/lago-pdf/values.yaml
+++ b/charts/lago-pdf/values.yaml
@@ -336,8 +336,7 @@ worker:
     command: ["./scripts/start.worker.sh"]
     # -- Worker container ports (none needed)
     # @section -- PDF Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Gotenberg HTML-to-PDF conversion service
 # @section -- Gotenberg

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -339,24 +339,22 @@ spec:
             {{- end }}
             {{- end }}
           {{- with .Values.container.ports }}
-          {{- if .enabled }}
           ports:
-            - name: http
-              containerPort: {{ .http }}
-              protocol: TCP
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- end }}
-          {{- with .Values.livenessProbe }}
-          {{- if .enabled }}
+          {{- if .Values.customLivenessProbe }}
           livenessProbe:
-            {{- omit . "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- end }}
-          {{- with .Values.readinessProbe }}
-          {{- if .enabled }}
+          {{- if .Values.customReadinessProbe }}
           readinessProbe:
-            {{- omit . "enabled" | toYaml | nindent 12 }}
-          {{- end }}
+            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -392,13 +392,13 @@ container:
   # -- Container command arguments
   # @section -- Container
   args: []
+  # -- Container ports. Set to `[]` (in the parent chart) to disable, e.g. for workers/clock.
+  # Lists replace on merge, so an empty list from a parent value cleanly overrides.
+  # @section -- Container
   ports:
-    # -- Enable the HTTP container port (disabled for workers/clock)
-    # @section -- Container
-    enabled: true
-    # -- HTTP container port
-    # @section -- Container
-    http: 3000
+    - name: http
+      containerPort: 3000
+      protocol: TCP
 
 # -- Number of replicas (ignored when autoscaling is enabled)
 # @section -- Deployment
@@ -552,12 +552,11 @@ httpRoute:
 # @section -- Pod
 resources: {}
 
-# -- Liveness probe configuration
+# -- Liveness probe configuration. Disable by setting `enabled: false` (e.g. for workers/clock).
+# Full replacement (e.g. `exec` for workers) goes through `customLivenessProbe`.
 # @default -- See [values.yaml](./values.yaml#L532)
 # @section -- Pod
 livenessProbe:
-  # -- Enable the liveness probe (disabled for workers/clock)
-  # @section -- Pod
   enabled: true
   failureThreshold: 5
   httpGet:
@@ -568,12 +567,15 @@ livenessProbe:
   periodSeconds: 30
   successThreshold: 1
   timeoutSeconds: 1
-# -- Readiness probe configuration
+# -- Custom liveness probe. When set (non-empty), this ProbeSpec replaces the default `livenessProbe`
+# above wholesale — useful for swapping `httpGet` for `exec` on workers without leaking the child's default.
+# @section -- Pod
+customLivenessProbe: {}
+# -- Readiness probe configuration. Disable by setting `enabled: false` (e.g. for workers/clock).
+# Full replacement goes through `customReadinessProbe`.
 # @default -- See [values.yaml](./values.yaml#L545)
 # @section -- Pod
 readinessProbe:
-  # -- Enable the readiness probe (disabled for workers/clock)
-  # @section -- Pod
   enabled: true
   failureThreshold: 3
   httpGet:
@@ -584,6 +586,9 @@ readinessProbe:
   periodSeconds: 3
   successThreshold: 1
   timeoutSeconds: 1
+# -- Custom readiness probe. When set (non-empty), this ProbeSpec replaces the default `readinessProbe`.
+# @section -- Pod
+customReadinessProbe: {}
 
 autoscaling:
   # -- Enable Horizontal Pod Autoscaler

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -401,8 +401,7 @@ worker:
     command: ["./scripts/start.worker.sh"]
     # -- Worker container ports (none needed)
     # @section -- Default Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Clock scheduler subchart overrides (lago-rails)
 # @default -- See child values
@@ -436,8 +435,7 @@ clock:
     command: ["./scripts/start.clock.sh"]
     # -- Clock container ports (none needed)
     # @section -- Clock
-    ports:
-      enabled: false
+    ports: []
 
 # -- Analytics worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.analytics`)
 # @default -- See child values
@@ -471,8 +469,7 @@ analytics-worker:
     command: ["./scripts/start.analytics.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Analytics Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Billing worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.billing`)
 # @default -- See child values
@@ -506,8 +503,7 @@ billing-worker:
     command: ["./scripts/start.billing.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Billing Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Clock worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.clock`)
 # @default -- See child values
@@ -541,8 +537,7 @@ clock-worker:
     command: ["./scripts/start.clock.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Clock Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Events worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.events`)
 # @default -- See child values
@@ -576,8 +571,7 @@ events-worker:
     command: ["./scripts/start.events.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Events Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Webhook worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.webhook`)
 # @default -- See child values
@@ -611,8 +605,7 @@ webhook-worker:
     command: ["./scripts/start.webhook.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Webhook Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- PDF worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.pdf`)
 # @default -- See child values
@@ -646,8 +639,7 @@ pdf-worker:
     command: ["./scripts/start.pdfs.worker.sh"]
     # -- Container ports (none needed)
     # @section -- PDF Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- PDF stack (gotenberg) subchart overrides
 # @default -- See child values
@@ -697,8 +689,7 @@ events-consumer-worker:
     command: ["./scripts/start.events.consumer.sh"]
     # -- Container ports (none needed)
     # @section -- Events Consumer Worker
-    ports:
-      enabled: false
+    ports: []
 
 # -- Events processor worker subchart overrides (conditional on `global.streaming_ingestion.enabled`)
 # @default -- See child values


### PR DESCRIPTION
Stacked on top of #221. Please merge #221 first (or retarget this to `lago-v2` after).

## Why

#221 fixes the underlying bug (Helm strips `null` from parent chart values, so worker/clock probe & port overrides leaked back into the rendered pod spec). It works, but the shape is unfamiliar in a few places:

- `container.ports.enabled: false` sits inside what is otherwise a map of named ports (`http: 3000`), mixing schema (which ports exist) with control (whether to render them).
- The `enabled` flag doesn't survive if a caller ever wants to **replace** a probe (e.g. swap `httpGet` for `exec` on a worker to check the process directly). Setting `livenessProbe.exec` in the umbrella while the child default has `livenessProbe.httpGet` deep-merges into an invalid `ProbeSpec` with both handler types.

## What changes

Split the fix by shape, reusing well-established patterns:

1. **`container.ports` → list.** The Kubernetes pod-spec `ports` is a list. Helm replaces lists on parent → subchart coalesce (verified empirically — empty maps and nulls both get merged/stripped; empty lists actually override). The umbrella just says `container.ports: []` for workers/clock. No `enabled` flag on ports.
2. **`livenessProbe` / `readinessProbe`** keep the `enabled` toggle (Bitnami-standard for probes) **and** get sibling `customLivenessProbe` / `customReadinessProbe` escape hatches. When non-empty they replace the default probe wholesale — clean way to hand a worker an `exec` probe without leaking the API's `httpGet`.

```yaml
# example: worker with an exec liveness probe
worker:
  container:
    ports: []
  livenessProbe:
    enabled: false          # turn off the default httpGet probe
  customLivenessProbe:
    exec:
      command: [/bin/sh, -c, "pgrep -f sidekiq || exit 1"]
    periodSeconds: 30
```

Reference: this is the pattern used by Bitnami's `bitnami/redis`, `bitnami/postgresql`, `bitnami/nginx` (`customLivenessProbe` / `customReadinessProbe` / `customStartupProbe`).

## Verification

- `task test:unit` — all suites pass.
- `helm lint ./charts/{lago-rails,lago-pdf,lago}` — clean.
- `task render` (umbrella with `basic_workers.yaml`) — `lago-api` and `lago-front` render ports + probes; every worker/clock deployment (`worker`, `clock`, `analytics-worker`, `billing-worker`, `clock-worker`, `events-worker`, `webhook-worker`, `pdf-worker`, `events-consumer-worker`) renders with no ports and no probes.

## Test plan
- [ ] `task test:unit`
- [ ] `task render` — inspect API vs worker deployments
- [ ] Try setting a `customLivenessProbe.exec` on a worker in a local values file and confirm it renders as the sole probe