### PR TITLE
feat(lago-rails): configurable DB session timeouts (INF-294)

### DIFF
--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -73,6 +73,22 @@ spec:
             - name: DATABASE_PREPARED_STATEMENTS
               value: {{ .Values.global.database.preparedStatement | quote }}
             {{- end }}
+            {{/* DB session timeouts. Per-instance override wins over the umbrella default; rendered only when set so an unset value falls back to the Postgres server default. */}}
+            {{- $statementTimeout := default .Values.global.database.statementTimeout .Values.config.database.statementTimeout }}
+            {{- if $statementTimeout }}
+            - name: LAGO_DATABASE_STATEMENT_TIMEOUT
+              value: {{ $statementTimeout | quote }}
+            {{- end }}
+            {{- $idleInTransactionTimeout := default .Values.global.database.idleInTransactionTimeout .Values.config.database.idleInTransactionTimeout }}
+            {{- if $idleInTransactionTimeout }}
+            - name: LAGO_DATABASE_IDLE_TX_TIMEOUT
+              value: {{ $idleInTransactionTimeout | quote }}
+            {{- end }}
+            {{- $lockTimeout := default .Values.global.database.lockTimeout .Values.config.database.lockTimeout }}
+            {{- if $lockTimeout }}
+            - name: LAGO_DATABASE_LOCK_TIMEOUT
+              value: {{ $lockTimeout | quote }}
+            {{- end }}
             - name: LAGO_SIDEKIQ_PRO_REQUIRED
               value: {{ .Values.global.sidekiq.pro | quote }}
             - name: LAGO_SIDEKIQ_WEB

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -76,6 +76,21 @@ global:
     # explicitly set.
     # @section -- Database
     preparedStatement:
+    # -- (int, milliseconds) Per-instance `statement_timeout`, rendered as
+    # `LAGO_DATABASE_STATEMENT_TIMEOUT`. Overrides `global.database.statementTimeout`.
+    # Unset → falls back to the Postgres server default.
+    # @section -- Database
+    statementTimeout:
+    # -- (int, milliseconds) Per-instance `idle_in_transaction_session_timeout`,
+    # rendered as `LAGO_DATABASE_IDLE_TX_TIMEOUT`. Overrides
+    # `global.database.idleInTransactionTimeout`. Unset → Postgres server default.
+    # @section -- Database
+    idleInTransactionTimeout:
+    # -- (int, milliseconds) Per-instance `lock_timeout`, rendered as
+    # `LAGO_DATABASE_LOCK_TIMEOUT`. Overrides `global.database.lockTimeout`.
+    # Unset → Postgres server default.
+    # @section -- Database
+    lockTimeout:
 
   encryption:
     # -- Primary encryption key (`openssl rand -hex 16`)

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -81,6 +81,21 @@ global:
     # explicitly set.
     # @section -- Database
     preparedStatement:
+    # -- (int, milliseconds) Default `statement_timeout` for every Rails pod,
+    # rendered as `LAGO_DATABASE_STATEMENT_TIMEOUT`. Per-component
+    # `config.database.statementTimeout` overrides. Unset → Postgres server default.
+    # @section -- Database
+    statementTimeout:
+    # -- (int, milliseconds) Default `idle_in_transaction_session_timeout`,
+    # rendered as `LAGO_DATABASE_IDLE_TX_TIMEOUT`. Per-component override via
+    # `config.database.idleInTransactionTimeout`. Unset → Postgres server default.
+    # @section -- Database
+    idleInTransactionTimeout:
+    # -- (int, milliseconds) Default `lock_timeout`, rendered as
+    # `LAGO_DATABASE_LOCK_TIMEOUT`. Per-component override via
+    # `config.database.lockTimeout`. Unset → Postgres server default.
+    # @section -- Database
+    lockTimeout:
 
   encryption:
     # -- Primary encryption key (`openssl rand -hex 16`)


### PR DESCRIPTION
## What

Exposes three PostgreSQL session timeouts as first-class, overridable chart values on every Rails component (`api`, `worker`, `clock`, and all Sidekiq workers), rendered as the env vars the app already reads in `config/database.yml`:

| Value | Env var | Postgres GUC |
|---|---|---|
| `statementTimeout` | `LAGO_DATABASE_STATEMENT_TIMEOUT` | `statement_timeout` |
| `idleInTransactionTimeout` | `LAGO_DATABASE_IDLE_TX_TIMEOUT` | `idle_in_transaction_session_timeout` |
| `lockTimeout` | `LAGO_DATABASE_LOCK_TIMEOUT` | `lock_timeout` |

## How

Follows the existing `pool` / `preparedStatement` idiom:

- Set a shared default under `global.database.*`.
- Override per component under `<component>.config.database.*` (component wins).
- The env var is rendered **only when a value is set**, so leaving it unset falls back to the Postgres server default — **no behavior change for existing installs**.

Values pass straight through (milliseconds).

## Files

- `charts/lago-rails/templates/deployment.yaml` — render the three env vars
- `charts/lago-rails/values.yaml` — document `config.database.*`
- `charts/lago/values.yaml` — document `global.database.*`

## Validation

`helm template` against the real lago-deploy values:
- Workers → all three (`120000` / `120000` / `15000`)
- `api` → only `LAGO_DATABASE_LOCK_TIMEOUT=15000` (statement/idle untouched)

## Follow-ups (not in this PR)

- Coordinated chart **version bump** + OCI publish (version is pinned across 44 `Chart.yaml` files — release step).
- lago-deploy values PR (getlago/lago-deploy) sets the actual values for prod-eu-1 / staging-eu-1.

Ref: https://linear.app/getlago/issue/INF-294

🤖 Generated with [Claude Code](https://claude.com/claude-code)