### PR TITLE
feat: add meilisearch-worker

### DIFF
--- a/charts/lago/Chart.lock
+++ b/charts/lago/Chart.lock
@@ -41,5 +41,8 @@ dependencies:
 - name: lago-events-processor-worker
   repository: file://../lago-events-processor-worker
   version: 0.5.19
-digest: sha256:b51623072646ec83c9a2224880c98df9cac4b563a6073848bee5c0de81e4db71
-generated: "2026-07-16T15:37:05.731303719Z"
+- name: lago-rails
+  repository: file://../lago-rails
+  version: 0.5.19
+digest: sha256:f70e0b7dbf633de0e2906e4876a3581644a012d4a27924c6eeaa2fa4322398c1
+generated: "2026-07-16T13:05:44.940719-07:00"

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.20
+version: 0.5.19
 appVersion: v1.41.2
 
 dependencies:

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.19
+version: 0.5.20
 appVersion: v1.41.2
 
 dependencies:
@@ -84,6 +84,11 @@ dependencies:
     version: 0.5.19
     repository: "file://../lago-events-processor-worker"
     condition: global.streaming_ingestion.enabled
+  - name: lago-rails
+    alias: meilisearch-worker
+    version: 0.5.19
+    repository: "file://../lago-rails"
+    condition: global.sidekiq.queues.meilisearch
 
 annotations:
   org.opencontainers.image.source: "https://github.com/getlago/lago-helm-charts"

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -45,6 +45,9 @@ global:
       # -- Enable the PDF background queue
       # @section -- Sidekiq
       pdf: false
+      # -- Enable the Meilisearch indexing queue
+      # @section -- Sidekiq
+      meilisearch: false
 
   config:
     # -- Name of an existing ConfigMap for shared configuration (bypasses auto-generated configmap)
@@ -518,6 +521,40 @@ billing-worker:
     command: ["./scripts/start.billing.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Billing Worker
+    ports: []
+
+# -- Meilisearch worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.meilisearch`)
+# @default -- See child values
+# @section -- Meilisearch Worker
+meilisearch-worker:
+  # -- Override the meilisearch-worker subchart release name
+  # @section -- Meilisearch Worker
+  nameOverride: lago-meilisearch-worker
+  config:
+    # -- Disable nested config (uses parent config subchart)
+    # @section -- Meilisearch Worker
+    enabled: false
+    # -- Config subchart name override
+    # @section -- Meilisearch Worker
+    nameOverride: lago-config
+  # -- Liveness probe (disabled for workers)
+  # @section -- Meilisearch Worker
+  livenessProbe:
+    enabled: false
+  # -- Readiness probe (disabled for workers)
+  # @section -- Meilisearch Worker
+  readinessProbe:
+    enabled: false
+  service:
+    # -- Disable service (no inbound traffic)
+    # @section -- Meilisearch Worker
+    enabled: false
+  container:
+    # -- Meilisearch worker entrypoint command
+    # @section -- Meilisearch Worker
+    command: ["./scripts/start.meilisearch.worker.sh"]
+    # -- Container ports (none needed)
+    # @section -- Meilisearch Worker
     ports: []
 
 # -- Clock worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.clock`)


### PR DESCRIPTION
```
  Rollout order (there are hard dependencies)

  1. lago-helm-charts → merge to lago-v2, cut release 0.5.20.
  2. lago-infra → merge; pulumi up (re-seals lago-meilisearch with the API_KEY field + applies chartVersion 0.5.20). Sync the lago app.
  3. lago-deploy → merge; the chart now has meilisearch-worker and the env resolves from the re-sealed secret. Sync.
 ```