### PR TITLE
feat(chart): configurable DATABASE_URL secret key on lago-rails + migrate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ The canonical reference is `charts/lago-data-rev-rec/` — most recently restruc
 
 All charts share the same `version`. `charts/lago/Chart.yaml` is the source of truth — the release script's `bump_versions` reads its current version and `sed`s every other `Chart.yaml` from that exact string.
 
+**Never bump `version:` in a feature PR.** CI (`.github/workflows/chart-release.yml` → `release.sh` → `bump_versions`) owns version increments and does it in a dedicated release commit like `fd132a5 chore: bump chart versions to 0.7.0`. If you bump it in a feature PR, you race the release script and produce drift between the umbrella and its subcharts. Only touch `version:` when adding a **new** chart (see below).
+
 **Consequence (the one that bites):** if a chart's `version:` doesn't match the umbrella's current version, `bump_versions` silently skips it, and the drift recurs every release. Before committing a new chart, copy the umbrella's current `version:` value verbatim into the new `Chart.yaml`. See the skill for the full failure-mode walk-through.
 
 ## Adding a new chart

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago-rails.secretName" . }}
-                  key: database.uri
+                  key: {{ default "database.uri" .Values.config.database.secretKey }}
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -345,6 +345,13 @@ config:
     # -- (bool) Override `global.database.preparedStatement` for this instance
     # @section -- Config
     preparedStatement:
+    # -- Secret key that provides `DATABASE_URL` for this instance. Defaults
+    # to `database.uri` (the lago-config secret's primary URI). Override to
+    # point at an alternate key (e.g. `database.direct.uri`) when a workload
+    # needs a different endpoint — bypassing an RDS Proxy for pin-prone jobs
+    # or migrations is the driving use case.
+    # @section -- Config
+    secretKey:
 
   otel:
     # -- Enable OpenTelemetry tracing

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -85,7 +85,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago.secretName" . }}
-                  key: database.uri
+                  key: {{ default "database.uri" .Values.migrate.config.database.secretKey }}
               {{- end }}
             - name: LAGO_RSA_PRIVATE_KEY
               {{- with .Values.global.signing.rsa }}

--- a/charts/lago/tests/migrate_job_test.yaml
+++ b/charts/lago/tests/migrate_job_test.yaml
@@ -172,6 +172,20 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
+          value: database.uri
+
+  - it: should honour migrate.config.database.secretKey when overriding the URI key
+    set:
+      global.database.uri: ""
+      migrate.config.database.secretKey: database.direct.uri
+    release:
+      name: my-release
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
+          value: database.direct.uri
 
   # -------------------------------------------------------------------
   # Extra env / envFrom

--- a/charts/lago/tests/subchart_helper_resolution_test.yaml
+++ b/charts/lago/tests/subchart_helper_resolution_test.yaml
@@ -42,3 +42,67 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == "REDIS_URL")].valueFrom.configMapKeyRef.name
           value: custom-configmap-name
+
+  - it: should default DATABASE_URL secretKeyRef.key to database.uri
+    set:
+      global:
+        lago:
+          env: production
+          version: v1.0.0
+        urls:
+          api: http://api.test
+          front: http://front.test
+        database:
+          uri: ""
+        encryption:
+          key: test-key
+          salt: test-salt
+        signing:
+          hmac: test-hmac
+          rsa: test-rsa
+        redis:
+          uri: redis://localhost
+        redisCache:
+          uri: redis://localhost
+        redisStore:
+          uri: redis://localhost
+      api:
+        config:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
+          value: database.uri
+
+  - it: should honour api.config.database.secretKey when overriding the URI key
+    set:
+      global:
+        lago:
+          env: production
+          version: v1.0.0
+        urls:
+          api: http://api.test
+          front: http://front.test
+        database:
+          uri: ""
+        encryption:
+          key: test-key
+          salt: test-salt
+        signing:
+          hmac: test-hmac
+          rsa: test-rsa
+        redis:
+          uri: redis://localhost
+        redisCache:
+          uri: redis://localhost
+        redisStore:
+          uri: redis://localhost
+      api:
+        config:
+          enabled: false
+          database:
+            secretKey: database.direct.uri
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
+          value: database.direct.uri

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -879,6 +879,13 @@ migrate:
       # -- (bool) Override `global.database.preparedStatement` for this instance
       # @section -- Database Migration / Config
       preparedStatement:
+      # -- Secret key that provides `DATABASE_URL` for the migration job.
+      # Defaults to `database.uri`. Override to point at an alternate key
+      # (e.g. `database.direct.uri`) when migrations need a different
+      # endpoint — bypassing an RDS Proxy for DDL that would exceed the
+      # 16 KB per-statement pin threshold is the driving use case.
+      # @section -- Database Migration / Config
+      secretKey:
   image:
     # -- Migration job image repository
     # @section -- Database Migration


### PR DESCRIPTION
## Summary

Expose the secret key that provides `DATABASE_URL` as a chart value on the two hot spots where it's hardcoded — the lago-rails deployment template and the umbrella migrate-job template. Enables per-workload URI routing without introducing duplicate `env:` entries.

## Why

Chart 0.7.0's `charts/lago-rails/templates/deployment.yaml:112` and `charts/lago/templates/migrate-job.yaml:81` both hardcode `DATABASE_URL`'s `secretKeyRef.key` to `database.uri`. Fine for a single-URI deployment; breaks when a subset of pods needs a different endpoint (e.g. bypassing an RDS Proxy for pin-prone workloads).

Concrete driver: on `lago-prod-us-1`, `Subscriptions::OrganizationBillingService.billable_subscriptions` emits a **~28 KB CTE** per organization per hour that trips Postgres RDS Proxy's **non-tunable 16 KB per-statement pin threshold** — every borrowed proxy connection stays pinned to a single client session, effectively disabling multiplexing.

The corresponding infra PR ([lago-infrastructure#1320](https://github.com/getlago/lago-infrastructure/pull/1320), merged) already seals a second URI at `database.direct.uri` (pointing at the RDS instance, no proxy) alongside `database.uri`. We tried overriding `DATABASE_URL` via `extraEnv` in Argo values, but the chart still renders its own `env: DATABASE_URL:` entry — so two items with the same name land in the pod spec and Kubernetes structured-merge-diff (used by ArgoCD SSA and its diff calculator) rejects duplicate list-map keys at validation:

```
failed to build typed value from config resource:
.spec.template.spec.containers[name="clock-worker"].env:
duplicate entries for key [name="DATABASE_URL"]
```

## Changes

Two chart values, defaulting to the current behaviour so nothing changes for existing deployments:

- **`config.database.secretKey`** on `lago-rails` (default `database.uri`) — reached by every lago-rails alias in the umbrella chart (`api`, `worker`, `clock`, `clock-worker`, `meilisearch-worker`, `alerts-worker`, `wallets-worker`, `pdf-worker`, `events-consumer-worker`, `analytics-worker`, `billing-worker`, `webhook-worker`, `events-worker`, `clock-worker`).
- **`migrate.config.database.secretKey`** on `lago` umbrella (default `database.uri`) — for the standalone migrate Job.

Downstream override from `argo/.../lago-prod-us-1/lago/lago/values.yaml`:

\`\`\`yaml
migrate:
  config:
    database:
      secretKey: database.direct.uri
clock:
  config:
    database:
      secretKey: database.direct.uri
clock-worker:
  config:
    database:
      secretKey: database.direct.uri
\`\`\`

## Also: `CLAUDE.md` versioning rule

Documented that `version:` in `Chart.yaml` is owned by CI's release script (`bump_versions`) and never touched in feature PRs. Bumping in a PR races the dedicated release commit and produces the umbrella-vs-subchart drift the section already warns about.

## Tests

- `charts/lago/tests/migrate_job_test.yaml` — added default-key assertion, plus `migrate.config.database.secretKey` override case.
- `charts/lago/tests/subchart_helper_resolution_test.yaml` — added default-key assertion on the api subchart (a lago-rails alias), plus `api.config.database.secretKey` override case.

All 34 tests pass locally:

\`\`\`
$ helm unittest charts/lago -f tests/migrate_job_test.yaml -f tests/subchart_helper_resolution_test.yaml
 PASS  Test migrate job	charts/lago/tests/migrate_job_test.yaml
 PASS  Test lago-config helpers are resolved correctly from subcharts	charts/lago/tests/subchart_helper_resolution_test.yaml
Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       34 passed, 34 total
\`\`\`

## Compatibility

Defaults preserve the current behaviour (`database.uri`) so unchanged deployments render byte-identically. No secret-shape changes required on the infra side — `database.direct.uri` is already published from lago-infrastructure#1320 and just sits in the sealed secret until a downstream override references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)