### PR TITLE
feat(chart): add dedicated-worker subchart (isolated tenant Sidekiq)

### DIFF
--- a/charts/lago-config/templates/configmap.yaml
+++ b/charts/lago-config/templates/configmap.yaml
@@ -54,4 +54,8 @@ data:
   {{- with .Values.global.sentry.environment }}
   sentry.environment: {{ . | quote }}
   {{- end }}
+  {{- if .Values.global.sidekiq.queues.dedicated.enabled }}
+  sidekiq.dedicated.orgIds: {{ .Values.global.sidekiq.queues.dedicated.orgIds | quote }}
+  sidekiq.dedicated.refreshIntervalSeconds: {{ .Values.global.sidekiq.queues.dedicated.refreshIntervalSeconds | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -44,6 +44,20 @@ global:
       # -- Enable the PDF background queue
       # @section -- Sidekiq
       pdf: false
+      # -- Dedicated worker queue toggle (dict, unlike other queue flags).
+      # See charts/lago/values.yaml for the full contract.
+      # @section -- Sidekiq
+      dedicated:
+        # -- Gate for the dedicated worker: writes sidekiq.dedicated.*
+        # keys to the shared ConfigMap when true.
+        # @section -- Sidekiq
+        enabled: false
+        # -- Comma-separated tenant org UUIDs (LAGO_DEDICATED_WORKER_ORG_IDS).
+        # @section -- Sidekiq
+        orgIds: ""
+        # -- Optional refresh cadence (LAGO_DEDICATED_REFRESH_INTERVAL_SECONDS).
+        # @section -- Sidekiq
+        refreshIntervalSeconds: ""
 
   config:
     # -- Name of an existing ConfigMap for shared configuration (bypasses auto-generated configmap)

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -234,6 +234,28 @@ spec:
               value: {{ .Values.global.sidekiq.queues.alerts | quote }}
             - name: SIDEKIQ_WALLETS
               value: {{ .Values.global.sidekiq.queues.wallets | quote }}
+            {{- if .Values.global.sidekiq.queues.aiAgent }}
+            - name: SIDEKIQ_AI_AGENT
+              value: "true"
+            {{- end }}
+            {{/*
+              global.sidekiq.queues.dedicated.* is owned by the umbrella
+              chart (charts/lago/values.yaml + charts/lago-config). Traverse
+              with `dig` so lago-rails stays renderable standalone when
+              the key doesn't exist.
+            */}}
+            {{- if dig "sidekiq" "queues" "dedicated" "enabled" false .Values.global }}
+            - name: LAGO_DEDICATED_WORKER_ORG_IDS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lago-rails.configMapName" . }}
+                  key: sidekiq.dedicated.orgIds
+            - name: LAGO_DEDICATED_REFRESH_INTERVAL_SECONDS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lago-rails.configMapName" . }}
+                  key: sidekiq.dedicated.refreshIntervalSeconds
+            {{- end }}
             {{- if .Values.global.lago.pdfGeneration }}
             - name: LAGO_PDF_URL
               valueFrom:

--- a/charts/lago/Chart.lock
+++ b/charts/lago/Chart.lock
@@ -50,5 +50,11 @@ dependencies:
 - name: lago-rails
   repository: file://../lago-rails
   version: 0.7.3
-digest: sha256:4e20c9434779f8d678b148cf6095a6188fd0742a2b42676f03ecb08b964613a2
-generated: "2026-07-29T12:58:16.893679081Z"
+- name: lago-rails
+  repository: file://../lago-rails
+  version: 0.7.3
+- name: lago-rails
+  repository: file://../lago-rails
+  version: 0.7.3
+digest: sha256:82af801c40e044846a344bfb2a61c73a7a6450c4734a8f5eb3e13e0758529f16
+generated: "2026-08-03T12:57:46.248264+02:00"

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -99,6 +99,16 @@ dependencies:
     version: 0.7.3
     repository: "file://../lago-rails"
     condition: global.sidekiq.queues.wallets
+  - name: lago-rails
+    alias: dedicated-worker
+    version: 0.7.3
+    repository: "file://../lago-rails"
+    condition: global.sidekiq.queues.dedicated.enabled
+  - name: lago-rails
+    alias: ai-agent-worker
+    version: 0.7.3
+    repository: "file://../lago-rails"
+    condition: global.sidekiq.queues.aiAgent
 
 annotations:
   org.opencontainers.image.source: "https://github.com/getlago/lago-helm-charts"

--- a/charts/lago/tests/ai_agent_worker_test.yaml
+++ b/charts/lago/tests/ai_agent_worker_test.yaml
@@ -1,0 +1,64 @@
+suite: Test ai-agent-worker subchart is gated by global.sidekiq.queues.aiAgent
+  and invokes the sidekiq_ai_agent.yml config via its dedicated start script,
+  and that the toggle also renders SIDEKIQ_AI_AGENT=true on every rails pod so
+  any enqueuer can route AiConversations jobs to the ai_agent queue. Toggle off
+  → the env is absent (less noise on non-users of the feature).
+templates:
+  - charts/ai-agent-worker/templates/deployment.yaml
+  - charts/api/templates/deployment.yaml
+
+set:
+  global:
+    lago:
+      env: production
+      version: v1.0.0
+    urls:
+      api: http://api.test
+      front: http://front.test
+    database:
+      uri: postgresql://localhost
+    encryption:
+      key: test-key
+      salt: test-salt
+    signing:
+      hmac: test-hmac
+      rsa: test-rsa
+    redis:
+      uri: redis://localhost
+    redisCache:
+      uri: redis://localhost
+    redisStore:
+      uri: redis://localhost
+
+tests:
+  - it: renders the ai-agent-worker deployment with its dedicated start script
+    template: charts/ai-agent-worker/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.aiAgent: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lago-ai-agent-worker
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["./scripts/start.ai_agent.worker.sh"]
+
+  - it: renders SIDEKIQ_AI_AGENT=true on every rails pod when the toggle is on
+    template: charts/api/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.aiAgent: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIDEKIQ_AI_AGENT
+            value: "true"
+
+  - it: omits SIDEKIQ_AI_AGENT from rails pods when the toggle is off
+    template: charts/api/templates/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIDEKIQ_AI_AGENT
+            value: "true"

--- a/charts/lago/tests/dedicated_worker_test.yaml
+++ b/charts/lago/tests/dedicated_worker_test.yaml
@@ -1,0 +1,115 @@
+suite: Test dedicated-worker subchart is gated by global.sidekiq.queues.dedicated.enabled
+  and invokes the sidekiq_dedicated.yml config via its dedicated start script,
+  and that the other global.sidekiq.queues.dedicated.* values flow through the shared lago-config
+  ConfigMap and are consumed by every rails pod (worker + enqueue side) as
+  LAGO_DEDICATED_* env vars via configMapKeyRef.
+templates:
+  - charts/config/templates/configmap.yaml
+  - charts/dedicated-worker/templates/deployment.yaml
+  - charts/api/templates/deployment.yaml
+
+set:
+  global:
+    lago:
+      env: production
+      version: v1.0.0
+    urls:
+      api: http://api.test
+      front: http://front.test
+    database:
+      uri: postgresql://localhost
+    encryption:
+      key: test-key
+      salt: test-salt
+    signing:
+      hmac: test-hmac
+      rsa: test-rsa
+    redis:
+      uri: redis://localhost
+    redisCache:
+      uri: redis://localhost
+    redisStore:
+      uri: redis://localhost
+
+tests:
+  - it: renders the dedicated-worker deployment with its dedicated start script
+    template: charts/dedicated-worker/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.dedicated.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lago-dedicated-worker
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["./scripts/start.dedicated.worker.sh"]
+
+  - it: writes sidekiq.dedicated.orgIds into the shared lago-config ConfigMap when enabled
+    template: charts/config/templates/configmap.yaml
+    set:
+      global.sidekiq.queues.dedicated.enabled: true
+      global.sidekiq.queues.dedicated.orgIds: "f426f3c9-6b53-4970-86a0-b1f96254d623"
+    asserts:
+      - equal:
+          path: data["sidekiq.dedicated.orgIds"]
+          value: "f426f3c9-6b53-4970-86a0-b1f96254d623"
+
+  - it: writes both sidekiq.dedicated.* keys together when enabled (empty string for unset refresh)
+    template: charts/config/templates/configmap.yaml
+    set:
+      global.sidekiq.queues.dedicated.enabled: true
+      global.sidekiq.queues.dedicated.refreshIntervalSeconds: "10"
+    asserts:
+      - equal:
+          path: data["sidekiq.dedicated.refreshIntervalSeconds"]
+          value: "10"
+
+  - it: does NOT write sidekiq.dedicated.* keys when the toggle is off
+    template: charts/config/templates/configmap.yaml
+    set:
+      global.sidekiq.queues.dedicated.orgIds: "f426f3c9-6b53-4970-86a0-b1f96254d623"
+    asserts:
+      - notExists:
+          path: data["sidekiq.dedicated.orgIds"]
+      - notExists:
+          path: data["sidekiq.dedicated.refreshIntervalSeconds"]
+
+  - it: reads LAGO_DEDICATED_WORKER_ORG_IDS via configMapKeyRef on the worker when enabled
+    template: charts/dedicated-worker/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.dedicated.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_DEDICATED_WORKER_ORG_IDS
+            valueFrom:
+              configMapKeyRef:
+                name: RELEASE-NAME-lago-config
+                key: sidekiq.dedicated.orgIds
+
+  - it: also reads LAGO_DEDICATED_WORKER_ORG_IDS on every rails pod (enqueue side)
+    template: charts/api/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.dedicated.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_DEDICATED_WORKER_ORG_IDS
+            valueFrom:
+              configMapKeyRef:
+                name: RELEASE-NAME-lago-config
+                key: sidekiq.dedicated.orgIds
+
+  - it: omits LAGO_DEDICATED_* env from rails pods when the toggle is off
+    template: charts/api/templates/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_DEDICATED_WORKER_ORG_IDS
+            valueFrom:
+              configMapKeyRef:
+                name: RELEASE-NAME-lago-config
+                key: sidekiq.dedicated.orgIds

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -54,6 +54,35 @@ global:
       # -- Enable the wallets background queue
       # @section -- Sidekiq
       wallets: false
+      # -- Enable the AI agent worker (isolates the `ai_agent` Sidekiq
+      # queue on a separate deployment; also renders `SIDEKIQ_AI_AGENT=true`
+      # on every rails workload so `AiConversations::StreamJob` enqueues to
+      # the `ai_agent` queue instead of `default`). Off by default.
+      # @section -- Sidekiq
+      aiAgent: false
+      # -- Dedicated worker queue toggle. Unlike the other queue flags this
+      # is a dict rather than a bool: the dedicated_alerts / dedicated_wallets
+      # queues are populated by per-org routing decisions in
+      # `Utils::DedicatedWorkerConfig`, which needs the tenant list at both
+      # enqueue and consume time. `enabled` gates the subchart + the shared
+      # ConfigMap keys; `orgIds` / `refreshIntervalSeconds` become
+      # LAGO_DEDICATED_WORKER_ORG_IDS / LAGO_DEDICATED_REFRESH_INTERVAL_SECONDS
+      # on every rails pod via configMapKeyRef.
+      # @section -- Sidekiq
+      dedicated:
+        # -- Enable the dedicated-worker subchart + propagate LAGO_DEDICATED_*
+        # env to every rails pod.
+        # @section -- Sidekiq
+        enabled: false
+        # -- Comma-separated tenant org UUIDs pinned to the dedicated_alerts
+        # / dedicated_wallets queues. Unset → key not written → env var
+        # absent → routing off.
+        # @section -- Sidekiq
+        orgIds: ""
+        # -- (int, seconds) Optional override for the org-list poll
+        # cadence. Unset → Rails default (5s) via `.presence.to_i`.
+        # @section -- Sidekiq
+        refreshIntervalSeconds: ""
 
   config:
     # -- Name of an existing ConfigMap for shared configuration (bypasses auto-generated configmap)
@@ -615,6 +644,85 @@ wallets-worker:
     command: ["./scripts/start.wallets.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Wallets Worker
+    ports: []
+
+# -- Dedicated worker subchart overrides (lago-rails, conditional on `global.sidekiq.dedicated.enabled`).
+# Runs `bundle exec sidekiq -C config/sidekiq/sidekiq_dedicated.yml` which
+# consumes the hard-coded `dedicated_alerts` + `dedicated_wallets` queues.
+# The tenant org routing list is set once at `global.sidekiq.dedicated.orgIds`
+# and rendered as `LAGO_DEDICATED_WORKER_ORG_IDS` on every rails pod (enqueue
+# side + consume side stay in sync automatically).
+# @default -- See child values
+# @section -- Dedicated Worker
+dedicated-worker:
+  # -- Override the dedicated-worker subchart release name
+  # @section -- Dedicated Worker
+  nameOverride: lago-dedicated-worker
+  config:
+    # -- Disable nested config (uses parent config subchart)
+    # @section -- Dedicated Worker
+    enabled: false
+    # -- Config subchart name override
+    # @section -- Dedicated Worker
+    nameOverride: lago-config
+  # -- Liveness probe (disabled for workers)
+  # @section -- Dedicated Worker
+  livenessProbe:
+    enabled: false
+  # -- Readiness probe (disabled for workers)
+  # @section -- Dedicated Worker
+  readinessProbe:
+    enabled: false
+  service:
+    # -- Disable service (no inbound traffic)
+    # @section -- Dedicated Worker
+    enabled: false
+  container:
+    # -- Dedicated worker entrypoint command — invokes sidekiq with the
+    # `sidekiq_dedicated.yml` config that hard-codes the two dedicated queues.
+    # @section -- Dedicated Worker
+    command: ["./scripts/start.dedicated.worker.sh"]
+    # -- Container ports (none needed)
+    # @section -- Dedicated Worker
+    ports: []
+
+# -- AI agent worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.aiAgent`).
+# Runs `bundle exec sidekiq -C config/sidekiq/sidekiq_ai_agent.yml` which
+# consumes the hard-coded `ai_agent` queue. Enqueuing side is gated by
+# `SIDEKIQ_AI_AGENT` (rendered on every rails workload from the same toggle);
+# `AiConversations::StreamJob` reads it to pick `:ai_agent` vs `:default`.
+# @default -- See child values
+# @section -- AI Agent Worker
+ai-agent-worker:
+  # -- Override the ai-agent-worker subchart release name
+  # @section -- AI Agent Worker
+  nameOverride: lago-ai-agent-worker
+  config:
+    # -- Disable nested config (uses parent config subchart)
+    # @section -- AI Agent Worker
+    enabled: false
+    # -- Config subchart name override
+    # @section -- AI Agent Worker
+    nameOverride: lago-config
+  # -- Liveness probe (disabled for workers)
+  # @section -- AI Agent Worker
+  livenessProbe:
+    enabled: false
+  # -- Readiness probe (disabled for workers)
+  # @section -- AI Agent Worker
+  readinessProbe:
+    enabled: false
+  service:
+    # -- Disable service (no inbound traffic)
+    # @section -- AI Agent Worker
+    enabled: false
+  container:
+    # -- AI agent worker entrypoint command — invokes sidekiq with the
+    # `sidekiq_ai_agent.yml` config that hard-codes the `ai_agent` queue.
+    # @section -- AI Agent Worker
+    command: ["./scripts/start.ai_agent.worker.sh"]
+    # -- Container ports (none needed)
+    # @section -- AI Agent Worker
     ports: []
 
 # -- Meilisearch worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.meilisearch`)


### PR DESCRIPTION
## Summary

Add two `lago-rails` aliases to the umbrella that were missing from the porter → helm parity list — `dedicated-worker` (isolated tenant Sidekiq) and `ai-agent-worker` — and route the dedicated-worker's tenant routing list through the shared `lago-config` ConfigMap so it stays a single-source-of-truth value shared by every rails pod (worker + enqueue side).

## dedicated-worker

Runs `./scripts/start.dedicated.worker.sh` → `sidekiq -C config/sidekiq/sidekiq_dedicated.yml`, which hard-codes:

- `dedicated_alerts`
- `dedicated_wallets`

Rails-side `Utils::DedicatedWorkerConfig` reads `LAGO_DEDICATED_WORKER_ORG_IDS` and routes matching orgs' wallet + alert jobs to those queues; everyone else keeps enqueueing to the shared `alerts` / `wallets` queues consumed by `alerts-worker` / `wallets-worker`. Both the enqueue side (api, clock, `*-worker`) and the consumer side (the dedicated deployment) have to see the same org list — so it lives on the shared `lago-config` ConfigMap, same place as the redis URIs, sentry env, MCP endpoint, and other shared runtime values.

## Design: shared runtime config flows through lago-config

`dedicated` sits under `global.sidekiq.queues.dedicated` alongside the other queue toggles. It's the only entry that's a dict (rather than a bool) because the feature has state beyond on/off — the tenant list has to be shared between enqueue side and consume side, so it goes through the ConfigMap:

```
global.sidekiq.queues.dedicated.orgIds  (+ refreshIntervalSeconds)
        │
        ▼
lago-config ConfigMap
  data:
    sidekiq.dedicated.orgIds: <uuid,uuid,...>
    sidekiq.dedicated.refreshIntervalSeconds: <n>
        │  configMapKeyRef (both keys always render together when enabled=true)
        ▼
LAGO_DEDICATED_WORKER_ORG_IDS + LAGO_DEDICATED_REFRESH_INTERVAL_SECONDS
on every rails pod (api, clock, worker, *-worker, dedicated-worker)
```

`enabled` drives everything: it gates the Chart.yaml `condition:` for the subchart, gates the ConfigMap key writes, and gates the env-var render on every rails pod. When off, there's zero mention of `LAGO_DEDICATED_*` or `sidekiq.dedicated.*` anywhere in the rendered output.

## ai-agent-worker

Runs `./scripts/start.ai_agent.worker.sh` → `sidekiq -C config/sidekiq/sidekiq_ai_agent.yml`, consuming the `ai_agent` queue. `AiConversations::StreamJob` checks `SIDEKIQ_AI_AGENT` at enqueue time to pick `:ai_agent` vs `:default`, so the toggle also renders that env on every rails pod. Kept gated (env absent when off) rather than always-`"false"` to keep noise out of pod specs on envs that don't use the feature.

## Chart changes

- **`charts/lago/Chart.yaml`** — two new `lago-rails` aliases:
  - `dedicated-worker`, gated on `global.sidekiq.queues.dedicated.enabled`
  - `ai-agent-worker`, gated on `global.sidekiq.queues.aiAgent`
- **`charts/lago/values.yaml`**:
  - New `global.sidekiq.queues.aiAgent: false` (bool)
  - New `global.sidekiq.queues.dedicated: {enabled, orgIds, refreshIntervalSeconds}` dict
  - `dedicated-worker:` and `ai-agent-worker:` blocks mirroring the `alerts-worker` / `wallets-worker` shape (nameOverride, disabled probes/service, `ports: []`, command)
- **`charts/lago-config/values.yaml`** + **`templates/configmap.yaml`** — declare the `queues.dedicated.*` schema and render two new ConfigMap keys (`sidekiq.dedicated.orgIds`, `sidekiq.dedicated.refreshIntervalSeconds`) under `if enabled`, matching the existing redis / sentry pattern.
- **`charts/lago-rails/templates/deployment.yaml`** — adds env entries next to the existing `SIDEKIQ_*` block:
  - `SIDEKIQ_AI_AGENT: "true"` gated on the toggle
  - `LAGO_DEDICATED_WORKER_ORG_IDS` and `LAGO_DEDICATED_REFRESH_INTERVAL_SECONDS` via `configMapKeyRef`, gated on the `enabled` flag through `dig` (safe when lago-rails renders standalone)
- **`charts/lago/Chart.lock`** — regenerated for the new alias entries.
- **Tests**: new `ai_agent_worker_test.yaml` (subchart + `SIDEKIQ_AI_AGENT` on rails pods, toggle-on/off) + extended `dedicated_worker_test.yaml` (ConfigMap key writes, `configMapKeyRef` shape on both worker and api pods, toggle-off omission).

## Downstream wiring (caller / lago-deploy)

- `global.sidekiq.queues.dedicated.enabled: true` + `global.sidekiq.queues.dedicated.orgIds: "uuid1,uuid2"` — set once at the top level.
- **When the caller opts out of chart-created config** (`configmap.create: false`, e.g. Pulumi LagoConfig on lago-prod-us-1 which owns the sealed `lago-config` ConfigMap), the two new keys need to be added to the externally-managed ConfigMap; otherwise the `configMapKeyRef` references miss.
- `dedicated-worker.config.sidekiq.concurrency: 3` — legacy prod-us runs 3, chart default is 5
- `dedicated-worker.image.repository` — env-specific ECR repo
- `global.sidekiq.queues.aiAgent: true` + `ai-agent-worker.image.repository` for the AI agent path

## Compatibility

Both features are off by default. Existing envs render byte-identically until they explicitly opt in. Toggle off → zero `LAGO_DEDICATED_*` or `SIDEKIQ_AI_AGENT` in any pod spec, no `sidekiq.dedicated.*` keys in the ConfigMap. Toggle on → both the ConfigMap keys and the env vars render together.

## Tests

```
$ task test:unit
Charts:      … all charts passed
Tests:       51 passed, 51 total
$ task lint
All charts linted successfully
```

Umbrella `helm template` with `global.sidekiq.queues.dedicated.enabled=true` renders the `lago-dedicated-worker` deployment, writes both `sidekiq.dedicated.*` keys to the `lago-config` ConfigMap, and every rails pod (9 in the `basic_workers.yaml` example) reads both env vars via `configMapKeyRef`.