### PR TITLE
feat(chart): optional DATABASE_PROXY_URL on lago-rails

### DIFF
--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -64,11 +64,19 @@ spec:
               value: {{ .Values.config.log.stdout | quote }}
             - name: DATABASE_POOL
               value: {{ default .Values.global.database.pool .Values.config.database.pool | quote }}
-            {{/* Per-instance override wins over the umbrella default. */}}
+            {{/* Precedence:
+                   1. Explicit per-instance override (`config.database.preparedStatement`).
+                   2. Auto-off when the workload uses the pooler — RDS Proxy for
+                      Postgres session-pins on prepared statements, so setting
+                      `config.database.proxy` implies statements must be off.
+                   3. Umbrella-wide default (`global.database.preparedStatement`).
+                 */}}
             {{- if kindIs "bool" .Values.config.database.preparedStatement }}
             - name: DATABASE_PREPARED_STATEMENTS
               value: {{ .Values.config.database.preparedStatement | quote }}
-            {{/* Fall back to the global value shared across every Rails pod. */}}
+            {{- else if .Values.config.database.proxy }}
+            - name: DATABASE_PREPARED_STATEMENTS
+              value: "false"
             {{- else if kindIs "bool" .Values.global.database.preparedStatement }}
             - name: DATABASE_PREPARED_STATEMENTS
               value: {{ .Values.global.database.preparedStatement | quote }}
@@ -113,7 +121,14 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago-rails.secretName" . }}
-                  key: {{ default "database.uri" .Values.config.database.secretKey }}
+                  key: database.uri
+            {{- with .Values.config.database.proxy }}
+            - name: DATABASE_PROXY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lago-rails.secretName" $ }}
+                  key: {{ . }}
+            {{- end }}
             - name: ENCRYPTION_PRIMARY_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -345,13 +345,16 @@ config:
     # -- (bool) Override `global.database.preparedStatement` for this instance
     # @section -- Config
     preparedStatement:
-    # -- Secret key that provides `DATABASE_URL` for this instance. Defaults
-    # to `database.uri` (the lago-config secret's primary URI). Override to
-    # point at an alternate key (e.g. `database.direct.uri`) when a workload
-    # needs a different endpoint — bypassing an RDS Proxy for pin-prone jobs
-    # or migrations is the driving use case.
+    # -- Name of the secret key that provides `DATABASE_PROXY_URL`.
+    # Optional. When set, the pod is exposed to a pooler / RDS Proxy URL
+    # in addition to the (direct) `DATABASE_URL`. The app decides routing:
+    # `:writing` traffic goes through the pooler, `:direct` traffic bypasses
+    # it. Setting this also implies `DATABASE_PREPARED_STATEMENTS=false`
+    # (unless overridden here or globally) — RDS Proxy session-pins on
+    # prepared statements, so the two knobs must move together. Point at
+    # `database.proxy.uri` (or a custom key) in the lago-config secret.
     # @section -- Config
-    secretKey:
+    proxy:
 
   otel:
     # -- Enable OpenTelemetry tracing

--- a/charts/lago/templates/migrate-job.yaml
+++ b/charts/lago/templates/migrate-job.yaml
@@ -85,7 +85,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "lago.secretName" . }}
-                  key: {{ default "database.uri" .Values.migrate.config.database.secretKey }}
+                  key: database.uri
               {{- end }}
             - name: LAGO_RSA_PRIVATE_KEY
               {{- with .Values.global.signing.rsa }}

--- a/charts/lago/tests/migrate_job_test.yaml
+++ b/charts/lago/tests/migrate_job_test.yaml
@@ -176,16 +176,14 @@ tests:
           path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
           value: database.uri
 
-  - it: should honour migrate.config.database.secretKey when overriding the URI key
+  - it: should not expose DATABASE_PROXY_URL from the migrate job
     set:
       global.database.uri: ""
-      migrate.config.database.secretKey: database.direct.uri
     release:
       name: my-release
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
-          value: database.direct.uri
+      - isNull:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_PROXY_URL")]
 
   # -------------------------------------------------------------------
   # Extra env / envFrom

--- a/charts/lago/tests/subchart_helper_resolution_test.yaml
+++ b/charts/lago/tests/subchart_helper_resolution_test.yaml
@@ -43,7 +43,7 @@ tests:
           path: spec.template.spec.containers[0].env[?(@.name == "REDIS_URL")].valueFrom.configMapKeyRef.name
           value: custom-configmap-name
 
-  - it: should default DATABASE_URL secretKeyRef.key to database.uri
+  - it: should bind DATABASE_URL to the database.uri secret key
     set:
       global:
         lago:
@@ -73,8 +73,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
           value: database.uri
+      - isNull:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_PROXY_URL")]
 
-  - it: should honour api.config.database.secretKey when overriding the URI key
+  - it: should expose DATABASE_PROXY_URL and auto-off prepared statements when config.database.proxy is set
     set:
       global:
         lago:
@@ -101,8 +103,48 @@ tests:
         config:
           enabled: false
           database:
-            secretKey: database.direct.uri
+            proxy: database.proxy.uri
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_URL")].valueFrom.secretKeyRef.key
-          value: database.direct.uri
+          value: database.uri
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_PROXY_URL")].valueFrom.secretKeyRef.key
+          value: database.proxy.uri
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_PREPARED_STATEMENTS")].value
+          value: "false"
+
+  - it: should let an explicit preparedStatement override win over the proxy auto-off
+    set:
+      global:
+        lago:
+          env: production
+          version: v1.0.0
+        urls:
+          api: http://api.test
+          front: http://front.test
+        database:
+          uri: ""
+        encryption:
+          key: test-key
+          salt: test-salt
+        signing:
+          hmac: test-hmac
+          rsa: test-rsa
+        redis:
+          uri: redis://localhost
+        redisCache:
+          uri: redis://localhost
+        redisStore:
+          uri: redis://localhost
+      api:
+        config:
+          enabled: false
+          database:
+            proxy: database.proxy.uri
+            preparedStatement: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "DATABASE_PREPARED_STATEMENTS")].value
+          value: "true"

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -879,13 +879,6 @@ migrate:
       # -- (bool) Override `global.database.preparedStatement` for this instance
       # @section -- Database Migration / Config
       preparedStatement:
-      # -- Secret key that provides `DATABASE_URL` for the migration job.
-      # Defaults to `database.uri`. Override to point at an alternate key
-      # (e.g. `database.direct.uri`) when migrations need a different
-      # endpoint — bypassing an RDS Proxy for DDL that would exceed the
-      # 16 KB per-statement pin threshold is the driving use case.
-      # @section -- Database Migration / Config
-      secretKey:
   image:
     # -- Migration job image repository
     # @section -- Database Migration


### PR DESCRIPTION
## Summary

Reverts #229's `config.database.secretKey` toggle and replaces it with an optional `DATABASE_PROXY_URL` env exposed on lago-rails pods.

### Contract

| Env var | Source | Semantics |
|---|---|---|
| `DATABASE_URL` | `database.uri` (always) | Direct connection to the physical database. |
| `DATABASE_PROXY_URL` | `config.database.proxy` (optional) | Pooler / RDS Proxy URL. When set, the Rails app routes `:writing` traffic through it and reserves `:direct` (via `DATABASE_URL`) for statements that would session-pin the pooler. |

The migrate job drops its `secretKey` override — migrations should always run direct (which was the whole reason for the override) and Rails now handles that via the multi-role connection map, not via env swap.

## Why the reshuffle

The `secretKey` toggle in #229 mutated which secret key `DATABASE_URL` binds to, so different workloads (`worker` vs `clock-worker`) got _different_ `DATABASE_URL` values pointing at _different_ endpoints. That works, but couples routing decisions to helm values that live per-workload — every time a job's SQL grows past 16 KB you have to touch infra.

With the new shape, every Rails workload receives the same `DATABASE_URL` (direct DB). The app-side change (getlago/lago-api#6029) declares a `:direct` ActiveRecord role that always uses `DATABASE_URL` and a `:writing` role that uses `DATABASE_PROXY_URL` when present. Routing lives in code, next to the query that needs it — infra just says "here's the pooler, opt in if you want it."

## Test plan

- [ ] `helm unittest charts/lago` passes (existing + new tests covering the proxy env)
- [ ] `helm unittest charts/lago-rails` passes
- [ ] Render `charts/lago` without `config.database.proxy` set → confirm pods only expose `DATABASE_URL`
- [ ] Render `charts/lago` with `config.database.proxy: database.proxy.uri` → confirm both `DATABASE_URL` and `DATABASE_PROXY_URL` appear
- [ ] Migrate job never exposes `DATABASE_PROXY_URL`