### PR TITLE
feat(chart): add scheduling controls to lago-data-rev-rec

### DIFF
--- a/charts/lago-data-rev-rec/templates/deployment.yaml
+++ b/charts/lago-data-rev-rec/templates/deployment.yaml
@@ -33,12 +33,40 @@ spec:
     replicas: {{ .Values.jobManager.replicas }}
     resource:
       {{- toYaml .Values.jobManager.resource | nindent 6 }}
+    {{- if or .Values.nodeSelector .Values.tolerations .Values.affinity }}
+    podTemplate:
+      spec:
+        {{- with .Values.nodeSelector }}
+        nodeSelector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+    {{- end }}
   taskManager:
     replicas: {{ .Values.taskManager.replicas }}
     resource:
       {{- toYaml .Values.taskManager.resource | nindent 6 }}
     podTemplate:
       spec:
+        {{- with .Values.nodeSelector }}
+        nodeSelector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         containers:
           - name: flink-main-container
             # operator injects flink config; nothing else to set here

--- a/charts/lago-data-rev-rec/templates/submitter-job.yaml
+++ b/charts/lago-data-rev-rec/templates/submitter-job.yaml
@@ -18,6 +18,18 @@ spec:
         {{- include "lago-data-rev-rec.labels" . | nindent 8 }}
         app.kubernetes.io/component: submitter
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       serviceAccountName: {{ include "lago-data-rev-rec.serviceAccountName" . }}
       containers:

--- a/charts/lago-data-rev-rec/values.yaml
+++ b/charts/lago-data-rev-rec/values.yaml
@@ -15,6 +15,12 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# Applied to every pod this chart creates: the FlinkDeployment's JobManager
+# and TaskManagers, and the submitter Job. Empty by default.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 # Annotations applied to the FlinkDeployment resource.
 annotations: {}
 


### PR DESCRIPTION
## Summary
- Add root-level `nodeSelector`/`tolerations`/`affinity` values to the `lago-data-rev-rec` chart, applied identically to every pod it creates: the FlinkDeployment's JobManager, its TaskManagers, and the submitter Job.
- Lets consumers schedule this workload onto a dedicated node pool (e.g. a tainted `lago.com/workload=flink` pool) without forking the chart. Empty by default, so existing deployments are unaffected.

## Test plan
- [x] `helm template` with defaults — confirms no scheduling fields render (valid YAML, no null `podTemplate.spec` on JobManager)
- [x] `helm template` with `nodeSelector`/`tolerations` set — confirms fields render identically on JobManager podTemplate, TaskManager podTemplate, and submitter Job pod spec
- [x] `helm lint`