### PR TITLE
feat(lago-data-rev-rec): expose restartNonce on the FlinkDeployment

### DIFF
--- a/charts/lago-data-rev-rec/templates/deployment.yaml
+++ b/charts/lago-data-rev-rec/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   flinkVersion: {{ .Values.flinkVersion }}
   serviceAccount: {{ include "lago-data-rev-rec.serviceAccountName" . }}
+  {{- with .Values.restartNonce }}
+  restartNonce: {{ . }}
+  {{- end }}
   # The K8s operator manages kubernetes.cluster-id internally — setting it here
   # is rejected by the admission webhook.
   flinkConfiguration:

--- a/charts/lago-data-rev-rec/values.yaml
+++ b/charts/lago-data-rev-rec/values.yaml
@@ -29,6 +29,20 @@ labels: {}
 
 flinkVersion: v1_20
 
+# Populates FlinkDeployment.spec.restartNonce when set — the Flink K8s
+# operator's mechanism to force a spec-change reconcile without editing any
+# real field. Leave null in steady state so upgrades don't churn the JM.
+#
+# When to set (or bump): the operator's session-recovery path
+# (SessionReconciler.recoverSession) creates a JM Deployment without the
+# ownerReference + `flinkdeployment.flink.apache.org/generation` annotation
+# the observer requires, so any Deployment produced by that path is
+# perpetually flagged MISSING and the operator loops on 409-AlreadyExists
+# recreates. Setting or bumping restartNonce routes the next reconcile
+# through SessionReconciler.deploy() instead, which stamps both markers
+# correctly.
+restartNonce: null
+
 jobManager:
   replicas: 2
   resource:


### PR DESCRIPTION
## Summary

Adds an optional \`restartNonce\` value to the \`lago-data-rev-rec\` chart. When set, the chart renders \`FlinkDeployment.spec.restartNonce\`; unset renders nothing, so existing installs don't churn on upgrade.

## Why

The Flink Kubernetes Operator's session-recovery path — \`SessionReconciler.recoverSession()\` (\`.../reconciler/deployment/SessionReconciler.java:123-128\` at commit \`b40c553\`, roughly release 1.10) — calls \`submitSessionCluster(ctx.getObserveConfig())\`. \`observeConfig\` bypasses both \`setOwnerReference()\` (\`AbstractFlinkResourceReconciler.java:543-554\`) and \`setGenerationAnnotation()\` (via \`FlinkConfigManager.getDeployConfig()\`), so any JM Deployment produced by that path is missing the \`ownerReferences: [FlinkDeployment/…]\` and the \`flinkdeployment.flink.apache.org/generation\` annotation the observer's \`checkIfAlreadyUpgraded()\` reads (\`AbstractFlinkDeploymentObserver.java:267-290\`). Result: the observer perpetually flags the JM Deployment MISSING → the operator tries to recreate → 409 AlreadyExists → residual cleanup deletes it → loop, forever.

Hit today on \`lago-prod-us-1\` after an EKS Auto Mode drift roll evicted both JMs + the operator simultaneously ([INC-248](https://app.incident.io/getlago/incidents/248)). Manual \`kubectl patch flinkdeployment rev-rec --type=merge -p '{\"spec\":{\"restartNonce\":1}}'\` broke the loop by routing the next reconcile through \`AbstractFlinkResourceReconciler.reconcileSpecChange()\` → \`SessionReconciler.deploy()\`, which correctly stamps ownerRef + generation. This PR exposes that field so the recovery is declarative next time.

The PDB added in getlago/lago-infrastructure#1453 prevents the trigger from recurring (JMs can't be evicted together), so this is defense in depth — not the primary fix.

## Behaviour

\`\`\`yaml
# values (default)
restartNonce: null
\`\`\`
\`\`\`yaml
# rendered spec (no field)
spec:
  image: …
  flinkVersion: v1_20
  serviceAccount: …
  flinkConfiguration: …
\`\`\`

\`\`\`yaml
# values
restartNonce: 1
\`\`\`
\`\`\`yaml
# rendered spec
spec:
  image: …
  flinkVersion: v1_20
  serviceAccount: …
  restartNonce: 1
  flinkConfiguration: …
\`\`\`

## Test plan

- [x] \`helm template ./charts/lago-data-rev-rec\` with no \`restartNonce\` set → field absent from rendered spec
- [x] \`--set restartNonce=7\` → field present as \`restartNonce: 7\`
- [x] \`task lint\` passes across all charts
- [ ] After merge + chart release, a follow-up PR in \`lago-infrastructure\` sets \`restartNonce: 1\` for \`lago-prod-us-1\` via the Pulumi valuesObject / cluster values file so the current live value is declaratively pinned