### PR TITLE
feat(chart): add global.meilisearch integration block (url + apiKey)

### DIFF
--- a/charts/lago-config/templates/configmap.yaml
+++ b/charts/lago-config/templates/configmap.yaml
@@ -48,6 +48,9 @@ data:
   {{- if .Values.global.mcp.enabled }}
   mcp.endpoint: {{ required "global.mcp.endpoint is required" .Values.global.mcp.endpoint }}
   {{- end }}
+  {{- if .Values.global.meilisearch.enabled }}
+  meilisearch.endpoint: {{ required "global.meilisearch.url is required" .Values.global.meilisearch.url }}
+  {{- end }}
   {{- if .Values.global.data.enabled }}
   data.endpoint: {{ required "global.data.endpoint is required" .Values.global.data.endpoint }}
   {{- end }}

--- a/charts/lago-config/templates/secret.yaml
+++ b/charts/lago-config/templates/secret.yaml
@@ -67,6 +67,9 @@ data:
   mcp.clientId: {{ required "global.mcp.clientId is required" .Values.global.mcp.clientId | b64enc }}
   mcp.clientSecret: {{ required "global.mcp.clientSecret is required" .Values.global.mcp.clientSecret | b64enc }}
   {{- end }}
+  {{- if .Values.global.meilisearch.enabled }}
+  meilisearch.apiKey: {{ required "global.meilisearch.apiKey is required" .Values.global.meilisearch.apiKey | b64enc }}
+  {{- end }}
   {{- if .Values.global.data.enabled }}
   data.token: {{ required "global.data.token is required" .Values.global.data.token | b64enc }}
   {{- end }}

--- a/charts/lago-config/values.yaml
+++ b/charts/lago-config/values.yaml
@@ -248,6 +248,22 @@ global:
     # @section -- MCP
     endpoint:
 
+  meilisearch:
+    # -- Enable Meilisearch integration. When true, renders
+    # `LAGO_MEILISEARCH_URL`, `LAGO_MEILISEARCH_SEARCH_ENABLED` and
+    # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
+    # @section -- Meilisearch
+    enabled: false
+    # -- Meilisearch endpoint URL (e.g.
+    # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
+    # @section -- Meilisearch
+    url:
+    # -- Meilisearch API key (rendered into the shared ConfigMap-mate
+    # Secret as `meilisearch.apiKey`; projected as
+    # `LAGO_MEILISEARCH_API_KEY` on Rails pods).
+    # @section -- Meilisearch
+    apiKey:
+
   data:
     # -- Enable Lago Data analytics
     # @section -- Data

--- a/charts/lago-pdf/values.yaml
+++ b/charts/lago-pdf/values.yaml
@@ -201,6 +201,19 @@ global:
     # @section -- MCP
     endpoint:
 
+  meilisearch:
+    # -- Enable Meilisearch integration. When true, renders
+    # `LAGO_MEILISEARCH_URL`, `LAGO_MEILISEARCH_SEARCH_ENABLED` and
+    # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
+    # @section -- Meilisearch
+    enabled: false
+    # -- Meilisearch endpoint URL.
+    # @section -- Meilisearch
+    url:
+    # -- Meilisearch API key.
+    # @section -- Meilisearch
+    apiKey:
+
   data:
     # -- Enable Lago Data analytics
     # @section -- Data

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -379,6 +379,20 @@ spec:
                   name: {{ include "lago-rails.secretName" . }}
                   key: mcp.clientSecret
             {{- end }}
+            {{- if .Values.global.meilisearch.enabled }}
+            - name: LAGO_MEILISEARCH_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lago-rails.configMapName" . }}
+                  key: meilisearch.endpoint
+            - name: LAGO_MEILISEARCH_SEARCH_ENABLED
+              value: "true"
+            - name: LAGO_MEILISEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lago-rails.secretName" . }}
+                  key: meilisearch.apiKey
+            {{- end }}
             {{- if .Values.global.data.enabled }}
             - name: LAGO_DATA_API_URL
               valueFrom:

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -232,6 +232,22 @@ global:
     # @section -- MCP
     endpoint:
 
+  meilisearch:
+    # -- Enable Meilisearch integration. When true, renders
+    # `LAGO_MEILISEARCH_URL`, `LAGO_MEILISEARCH_SEARCH_ENABLED` and
+    # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
+    # @section -- Meilisearch
+    enabled: false
+    # -- Meilisearch endpoint URL (e.g.
+    # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
+    # @section -- Meilisearch
+    url:
+    # -- Meilisearch API key (rendered into the shared Secret as
+    # `meilisearch.apiKey`; projected as `LAGO_MEILISEARCH_API_KEY`
+    # on Rails pods).
+    # @section -- Meilisearch
+    apiKey:
+
   data:
     # -- Enable Lago Data analytics
     # @section -- Data

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -290,6 +290,22 @@ global:
     # @section -- MCP
     endpoint:
 
+  meilisearch:
+    # -- Enable Meilisearch integration. When true, renders
+    # `LAGO_MEILISEARCH_URL`, `LAGO_MEILISEARCH_SEARCH_ENABLED` and
+    # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
+    # @section -- Meilisearch
+    enabled: false
+    # -- Meilisearch endpoint URL (e.g.
+    # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
+    # @section -- Meilisearch
+    url:
+    # -- Meilisearch API key (rendered into the shared Secret as
+    # `meilisearch.apiKey`; projected as `LAGO_MEILISEARCH_API_KEY`
+    # on Rails pods).
+    # @section -- Meilisearch
+    apiKey:
+
   data:
     # -- Enable Lago Data analytics
     # @section -- Data


### PR DESCRIPTION
## Summary

Mirrors the existing `global.mcp` pattern to wire Meilisearch through the shared `lago-config` ConfigMap + Secret instead of every caller supplying `LAGO_MEILISEARCH_*` via `extraEnv`.

New values (declared on `lago`, `lago-config`, `lago-rails`, and `lago-pdf` so subcharts don't see `.Values.global.meilisearch` as `nil`):

```yaml
global:
  meilisearch:
    enabled: false
    url:
    apiKey:
```

When `enabled: true`:

- `lago-config` ConfigMap gains a `meilisearch.endpoint` key from `global.meilisearch.url` (required)
- `lago-config` Secret gains a `meilisearch.apiKey` key from `global.meilisearch.apiKey` (required)
- every `lago-rails` workload projects three env vars:
  - `LAGO_MEILISEARCH_URL` (configMapKeyRef → `meilisearch.endpoint`)
  - `LAGO_MEILISEARCH_SEARCH_ENABLED` = `"true"` (literal)
  - `LAGO_MEILISEARCH_API_KEY` (secretKeyRef → `meilisearch.apiKey`)

When `enabled: false`: none of these keys or env vars are rendered.

## Rationale

Legacy prod-us wires these via `extraEnv` (a `_meili` YAML anchor in lago-deploy) which is repeated on every worker that needs search. That anchor:
- inlines the URL as a literal on every workload,
- inlines `SEARCH_ENABLED="true"`,
- references a hand-rolled `lago-meilisearch` sealed Secret for the API key.

Consolidating into `global.meilisearch.*` moves those into the chart's shared ConfigMap + Secret and makes lago-deploy config a single 3-line block instead of an extraEnv anchor spread across 7 workers.

## Test plan

- [ ] `helm template test charts/lago -f examples/basic.yaml` renders no `LAGO_MEILISEARCH_*` env or `meilisearch.*` keys (default, `enabled: false`)
- [ ] `helm template ... --set global.meilisearch.enabled=true --set global.meilisearch.url=http://... --set global.meilisearch.apiKey=x` renders:
  - `meilisearch.endpoint` in the ConfigMap
  - `meilisearch.apiKey` (b64-encoded) in the Secret
  - `LAGO_MEILISEARCH_URL`, `LAGO_MEILISEARCH_SEARCH_ENABLED`, `LAGO_MEILISEARCH_API_KEY` on every `lago-rails`-derived Deployment
- [ ] `helm template ... --set global.meilisearch.enabled=true --set global.meilisearch.apiKey=x` (missing `url`) fails with `global.meilisearch.url is required`
- [ ] `helm template ... --set global.meilisearch.enabled=true --set global.meilisearch.url=x` (missing `apiKey`) fails with `global.meilisearch.apiKey is required`

## Follow-up

- Cut a chart release with this change
- Update lago-deploy to drop the `_meili` extraEnv anchor and set `global.meilisearch.{enabled,url,apiKey}` (+ seal the API key into the standard `lago-config` Secret instead of the standalone `lago-meilisearch` one)