### PR TITLE
feat(lago-pdf): default gotenberg to ghcr.io/getlago/gotenberg:8.32 with tuned runtime flags

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -9,7 +9,7 @@ vars:
       redis: redis:7-alpine
       api: getlago/api:{{.VERSION}}
       front: getlago/front:v1.41.0
-      gotenberg: getlago/lago-gotenberg:8.15
+      gotenberg: ghcr.io/getlago/gotenberg:8.32
   CHARTS:
     map:
       # Base configs (no dependencies)

--- a/charts/lago-pdf/Chart.yaml
+++ b/charts/lago-pdf/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: 0.9.0
 
-appVersion: "8"
+appVersion: "8.32"
 
 dependencies:
   - name: lago-config

--- a/charts/lago-pdf/README.md
+++ b/charts/lago-pdf/README.md
@@ -1,6 +1,6 @@
 # lago-pdf
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8](https://img.shields.io/badge/AppVersion-8-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.32](https://img.shields.io/badge/AppVersion-8.32-informational?style=flat-square)
 
 A Helm chart for the Lago PDF stack (Gotenberg + optional Rails worker)
 
@@ -8,8 +8,8 @@ A Helm chart for the Lago PDF stack (Gotenberg + optional Rails worker)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../lago-config | config(lago-config) | 0.5.0 |
-| file://../lago-rails | worker(lago-rails) | 0.5.0 |
+| file://../lago-config | config(lago-config) | 0.9.0 |
+| file://../lago-rails | worker(lago-rails) | 0.9.0 |
 
 ## Values
 
@@ -25,29 +25,27 @@ A Helm chart for the Lago PDF stack (Gotenberg + optional Rails worker)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| worker | object | `{"config":{"enabled":false,"nameOverride":"lago-pdf-config"},"container":{"command":["./scripts/start.worker.sh"],"ports":null},"enabled":true,"livenessProbe":null,"nameOverride":"lago-pdf-worker","readinessProbe":null,"service":{"enabled":false}}` | PDF worker subchart (lago-rails configured as a background worker) |
 | worker.enabled | bool | `true` | Deploy the PDF worker |
 | worker.nameOverride | string | `"lago-pdf-worker"` | Override the worker subchart release name |
 | worker.config.enabled | bool | `false` | Disable nested config (uses parent config) |
 | worker.config.nameOverride | string | `"lago-pdf-config"` | Config subchart name override |
 | worker.service.enabled | bool | `false` | Disable service for the worker (no inbound traffic) |
-| worker.livenessProbe | string | `nil` | Liveness probe (disabled for worker) |
-| worker.readinessProbe | string | `nil` | Readiness probe (disabled for worker) |
+| worker.livenessProbe | object | `{"enabled":false}` | Liveness probe (disabled for worker) |
+| worker.readinessProbe | object | `{"enabled":false}` | Readiness probe (disabled for worker) |
 | worker.container.command | list | `["./scripts/start.worker.sh"]` | Worker entrypoint command |
-| worker.container.ports | string | `nil` | Worker container ports (none needed) |
+| worker.container.ports | list | `[]` | Worker container ports (none needed) |
 
 ### Gotenberg
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| gotenberg | object | `{"affinity":{},"autoscaling":{"enabled":false,"external":false,"maxReplicas":100,"minReplicas":1,"targetCPUUtilizationPercentage":80},"container":{"args":["gotenberg","--api-disable-health-check-logging"],"command":[],"name":"","ports":{"http":3000}},"extraEnv":{},"extraEnvFrom":[],"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"getlago/lago-gotenberg","tag":null},"imagePullSecrets":[],"livenessProbe":{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":10,"periodSeconds":30},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"readinessProbe":{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":10,"periodSeconds":3},"replicaCount":1,"resources":{},"securityContext":{},"service":{"enabled":true,"port":80,"type":"ClusterIP"},"serviceAccount":{"annotations":{},"automount":true,"create":true,"name":""},"tolerations":[],"volumeMounts":[],"volumes":[]}` | Gotenberg HTML-to-PDF conversion service |
-| gotenberg.image.repository | string | `"getlago/lago-gotenberg"` | Gotenberg image repository |
+| gotenberg.image.repository | string | `"ghcr.io/getlago/gotenberg"` | Gotenberg image repository |
 | gotenberg.image.tag | string | `nil` | Override the Gotenberg image tag |
 | gotenberg.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | gotenberg.replicaCount | int | `1` | Number of Gotenberg replicas (ignored when autoscaling is enabled) |
 | gotenberg.container.name | string | `""` | Override the container name |
 | gotenberg.container.command | list | `[]` | Container entrypoint command |
-| gotenberg.container.args | list | `["gotenberg","--api-disable-health-check-logging"]` | Container command arguments |
+| gotenberg.container.args | list | `["gotenberg","--libreoffice-disable-routes=true","--chromium-ignore-certificate-errors=true","--chromium-disable-javascript=true","--api-timeout=30s","--chromium-max-queue-size=20","--chromium-restart-after=100"]` | Container command arguments. These are the best-performing values we have found in production: restart Chromium every 100 jobs to avoid zombie processes, cap the queue at 20, disable JS in invoice HTML, ignore certificate errors on the Chromium fetcher, disable LibreOffice routes we do not use, and cap the API timeout at 30s. `--api-disable-health-check-logging` was renamed to `--api-disable-health-check-route-telemetry` in Gotenberg 8.32 and defaults to `true`, so it is intentionally not set here. |
 | gotenberg.container.ports.http | int | `3000` | HTTP container port |
 | gotenberg.service.enabled | bool | `true` | Create a Service for Gotenberg |
 | gotenberg.service.type | string | `"ClusterIP"` | Service type |
@@ -84,9 +82,9 @@ A Helm chart for the Lago PDF stack (Gotenberg + optional Rails worker)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| annotations | object | `{}` | Deployment metadata annotations (e.g. Stakater Reloader) |
 | nameOverride | string | `""` | Override the chart name |
 | fullnameOverride | string | `""` | Override the full release name |
-| annotations | object | `{}` | Deployment metadata annotations |
 
 ### Extra Objects
 

--- a/charts/lago-pdf/values.yaml
+++ b/charts/lago-pdf/values.yaml
@@ -312,7 +312,6 @@ config:
   # @section -- PDF Config
   nameOverride: lago-pdf-config
 
-# -- PDF worker subchart (lago-rails configured as a background worker)
 # @section -- PDF Worker
 worker:
   # -- Deploy the PDF worker
@@ -351,13 +350,12 @@ worker:
     # @section -- PDF Worker
     ports: []
 
-# -- Gotenberg HTML-to-PDF conversion service
 # @section -- Gotenberg
 gotenberg:
   image:
     # -- Gotenberg image repository
     # @section -- Gotenberg
-    repository: getlago/lago-gotenberg
+    repository: ghcr.io/getlago/gotenberg
     # -- Override the Gotenberg image tag
     # @section -- Gotenberg
     tag:
@@ -376,9 +374,24 @@ gotenberg:
     # -- Container entrypoint command
     # @section -- Gotenberg
     command: []
-    # -- Container command arguments
+    # -- Container command arguments. These are the best-performing
+    # values we have found in production: restart Chromium every 100
+    # jobs to avoid zombie processes, cap the queue at 20, disable JS
+    # in invoice HTML, ignore certificate errors on the Chromium
+    # fetcher, disable LibreOffice routes we do not use, and cap the
+    # API timeout at 30s. `--api-disable-health-check-logging` was
+    # renamed to `--api-disable-health-check-route-telemetry` in
+    # Gotenberg 8.32 and defaults to `true`, so it is intentionally
+    # not set here.
     # @section -- Gotenberg
-    args: ["gotenberg", "--api-disable-health-check-logging"]
+    args:
+      - gotenberg
+      - --libreoffice-disable-routes=true
+      - --chromium-ignore-certificate-errors=true
+      - --chromium-disable-javascript=true
+      - --api-timeout=30s
+      - --chromium-max-queue-size=20
+      - --chromium-restart-after=100
     ports:
       # -- HTTP container port
       # @section -- Gotenberg


### PR DESCRIPTION
## Summary

The chart previously defaulted to `getlago/lago-gotenberg:8` on Docker Hub (last pushed 2024-05-07, Gotenberg 8.5.0), which defaults `--chromium-restart-after` to `0`. Chromium therefore never restarts, which reproduces the 5-minute request hang described in `scripts/pdf.rb` in `lago-infrastructure`.

Ship the seven-arg runtime configuration that is the best-performing set we have found in production. lago-infrastructure [#1483](https://github.com/getlago/lago-infrastructure/pull/1483) pinned these on the three managed clusters (`lago-prod-us-1`, `lago-prod-eu-1`, `lago-staging-eu-1`); **this PR lifts them to the chart default** so self-hosted users get the same behaviour.

## Changes

- **`Chart.yaml`**: `appVersion` `8` → `8.32`. The template resolves `gotenberg.image.tag | default .Chart.AppVersion`, so leaving `tag` empty renders `ghcr.io/getlago/gotenberg:8.32`.
- **`values.yaml`**: `gotenberg.image.repository` `getlago/lago-gotenberg` → `ghcr.io/getlago/gotenberg`. Both are public — no `imagePullSecrets` change needed.
- **`values.yaml`**: `gotenberg.container.args` replaced with the seven-arg set:
  ```yaml
  args:
    - gotenberg
    - --libreoffice-disable-routes=true
    - --chromium-ignore-certificate-errors=true
    - --chromium-disable-javascript=true
    - --api-timeout=30s
    - --chromium-max-queue-size=20
    - --chromium-restart-after=100
  ```
  The prior `--api-disable-health-check-logging` is intentionally dropped — it was renamed to `--api-disable-health-check-route-telemetry` in Gotenberg 8.32 and defaults to `true`, so health-check logging stays off without setting a flag.
- **`values.yaml`**: drop the top-level `# --` doc comment on `worker` and `gotenberg` so helm-docs stops emitting the aggregate JSON-dump rows. Sub-keys keep their individual documentation.
- **`Taskfile.yaml`**: dev/kind image ref bumped from `getlago/lago-gotenberg:8.15` → `ghcr.io/getlago/gotenberg:8.32` so local integration tests exercise the same image.
- **`README.md`**: regenerated via `helm-docs`.

## Behaviour change per flag

| Flag | 8.5.0 default | 8.32 default | New chart default |
|---|---|---|---|
| `--chromium-restart-after` | `0` (never restart) | `100` | `100` |
| `--chromium-max-queue-size` | `0` (unlimited) | `0` | `20` |
| `--chromium-disable-javascript` | `false` | `false` | `true` |
| `--chromium-ignore-certificate-errors` | `false` | `false` | `true` |
| `--libreoffice-disable-routes` | `false` | `false` | `true` |
| `--api-timeout` | `30s` | `30s` | `30s` (explicit) |

## Verified

`helm template` renders on the working tree:

```
image: "ghcr.io/getlago/gotenberg:8.32"
args: ["gotenberg","--libreoffice-disable-routes=true","--chromium-ignore-certificate-errors=true","--chromium-disable-javascript=true","--api-timeout=30s","--chromium-max-queue-size=20","--chromium-restart-after=100"]
```

## Follow-up

Once this ships and the chart version is bumped, the three per-cluster override blocks landed by lago-infrastructure #1483 (`argo/clusters/**/lago/lago/values.yaml`) become redundant and can be removed — happy to do that in a follow-up PR against `lago-infrastructure` gated on the `targetRevision` bump.

## Test plan

- [ ] `helm template` on each chart consumer (`lago`, `lago-pdf` standalone) still produces valid manifests
- [ ] CI passes (`ct lint`, `ct install`)
- [ ] After merge + version bump + `targetRevision` roll on the three clusters, `kubectl get deploy lago-pdf -o=jsonpath='{.spec.template.spec.containers[0].image}'` returns `ghcr.io/getlago/gotenberg:8.32` and args match the seven-arg list