### PR TITLE
feat(lago-rails): add global.meilisearch.search toggle for LAGO_MEILISEARCH_SEARCH_ENABLED

### DIFF
--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -386,7 +386,7 @@ spec:
                   name: {{ include "lago-rails.configMapName" . }}
                   key: meilisearch.endpoint
             - name: LAGO_MEILISEARCH_SEARCH_ENABLED
-              value: {{ .Values.global.meilisearch.searchEnabled | quote }}
+              value: {{ .Values.global.meilisearch.search | quote }}
             - name: LAGO_MEILISEARCH_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -386,7 +386,7 @@ spec:
                   name: {{ include "lago-rails.configMapName" . }}
                   key: meilisearch.endpoint
             - name: LAGO_MEILISEARCH_SEARCH_ENABLED
-              value: {{ .Values.meilisearch.searchEnabled | quote }}
+              value: {{ .Values.global.meilisearch.searchEnabled | quote }}
             - name: LAGO_MEILISEARCH_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lago-rails/templates/deployment.yaml
+++ b/charts/lago-rails/templates/deployment.yaml
@@ -386,7 +386,7 @@ spec:
                   name: {{ include "lago-rails.configMapName" . }}
                   key: meilisearch.endpoint
             - name: LAGO_MEILISEARCH_SEARCH_ENABLED
-              value: "true"
+              value: {{ .Values.meilisearch.searchEnabled | quote }}
             - name: LAGO_MEILISEARCH_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/lago-rails/tests/meilisearch_search_enabled_test.yaml
+++ b/charts/lago-rails/tests/meilisearch_search_enabled_test.yaml
@@ -25,11 +25,11 @@ tests:
             name: LAGO_MEILISEARCH_SEARCH_ENABLED
             value: "true"
 
-  - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="false" when meilisearch.searchEnabled=false
+  - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="false" when global.meilisearch.searchEnabled=false
     values:
       - ./fixtures/required.yaml
     set:
-      meilisearch.searchEnabled: false
+      global.meilisearch.searchEnabled: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -45,7 +45,7 @@ tests:
     values:
       - ./fixtures/required.yaml
     set:
-      meilisearch.searchEnabled: false
+      global.meilisearch.searchEnabled: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/lago-rails/tests/meilisearch_search_enabled_test.yaml
+++ b/charts/lago-rails/tests/meilisearch_search_enabled_test.yaml
@@ -13,7 +13,7 @@ set:
 
 tests:
   # ============================================================================
-  # meilisearch.searchEnabled (per-workload)
+  # global.meilisearch.search
   # ============================================================================
   - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="true" by default
     values:
@@ -25,11 +25,11 @@ tests:
             name: LAGO_MEILISEARCH_SEARCH_ENABLED
             value: "true"
 
-  - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="false" when global.meilisearch.searchEnabled=false
+  - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="false" when global.meilisearch.search=false
     values:
       - ./fixtures/required.yaml
     set:
-      global.meilisearch.searchEnabled: false
+      global.meilisearch.search: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -38,14 +38,14 @@ tests:
             value: "false"
 
   # LAGO_MEILISEARCH_URL and LAGO_MEILISEARCH_API_KEY stay wired even when
-  # searchEnabled is false — the workload can still hit Meilisearch for
+  # search is false — the workload can still hit Meilisearch for
   # non-search paths (e.g. indexing from a worker); only the read-side is
   # disabled.
-  - it: should still project URL + API_KEY when searchEnabled=false
+  - it: should still project URL + API_KEY when search=false
     values:
       - ./fixtures/required.yaml
     set:
-      global.meilisearch.searchEnabled: false
+      global.meilisearch.search: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -65,7 +65,7 @@ tests:
                 key: meilisearch.apiKey
 
   # When Meilisearch is globally disabled, the whole env block is elided
-  # regardless of the per-workload searchEnabled.
+  # regardless of `search`.
   - it: should not project the block when global.meilisearch.enabled=false
     values:
       - ./fixtures/required.yaml

--- a/charts/lago-rails/tests/meilisearch_search_enabled_test.yaml
+++ b/charts/lago-rails/tests/meilisearch_search_enabled_test.yaml
@@ -1,0 +1,82 @@
+suite: Test LAGO_MEILISEARCH_SEARCH_ENABLED projection
+templates:
+  - templates/deployment.yaml
+values:
+  - ../values.yaml
+
+# Common values that any deployment render needs; parked here so each
+# test doesn't re-set them.
+set:
+  global.meilisearch.enabled: true
+  global.meilisearch.url: "http://meilisearch.meilisearch.svc.cluster.local:7700"
+  global.meilisearch.apiKey: "test-key"
+
+tests:
+  # ============================================================================
+  # meilisearch.searchEnabled (per-workload)
+  # ============================================================================
+  - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="true" by default
+    values:
+      - ./fixtures/required.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_MEILISEARCH_SEARCH_ENABLED
+            value: "true"
+
+  - it: should project LAGO_MEILISEARCH_SEARCH_ENABLED="false" when meilisearch.searchEnabled=false
+    values:
+      - ./fixtures/required.yaml
+    set:
+      meilisearch.searchEnabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_MEILISEARCH_SEARCH_ENABLED
+            value: "false"
+
+  # LAGO_MEILISEARCH_URL and LAGO_MEILISEARCH_API_KEY stay wired even when
+  # searchEnabled is false — the workload can still hit Meilisearch for
+  # non-search paths (e.g. indexing from a worker); only the read-side is
+  # disabled.
+  - it: should still project URL + API_KEY when searchEnabled=false
+    values:
+      - ./fixtures/required.yaml
+    set:
+      meilisearch.searchEnabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_MEILISEARCH_URL
+            valueFrom:
+              configMapKeyRef:
+                name: RELEASE-NAME-lago-config
+                key: meilisearch.endpoint
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_MEILISEARCH_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-lago-config
+                key: meilisearch.apiKey
+
+  # When Meilisearch is globally disabled, the whole env block is elided
+  # regardless of the per-workload searchEnabled.
+  - it: should not project the block when global.meilisearch.enabled=false
+    values:
+      - ./fixtures/required.yaml
+    set:
+      global.meilisearch.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_MEILISEARCH_SEARCH_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_MEILISEARCH_URL

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -238,6 +238,15 @@ global:
     # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
     # @section -- Meilisearch
     enabled: false
+    # -- Value projected into `LAGO_MEILISEARCH_SEARCH_ENABLED` on
+    # every Rails workload. Defaults to `true`; set to `false` to
+    # keep the URL + API key wired (so indexing paths still work)
+    # but stop the api from serving search queries against
+    # Meilisearch — e.g. during a heavy backfill when search
+    # timeouts are amplifying load. Only takes effect when
+    # `enabled` is true (otherwise the whole env block is elided).
+    # @section -- Meilisearch
+    searchEnabled: true
     # -- Meilisearch endpoint URL (e.g.
     # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
     # @section -- Meilisearch
@@ -526,20 +535,6 @@ extraEnvFrom: []
   #     name: config-map-name
   # - secretRef:
   #     name: secret-name
-
-# Per-workload Meilisearch settings (only take effect when
-# `global.meilisearch.enabled` is true — the whole
-# `LAGO_MEILISEARCH_URL`/`LAGO_MEILISEARCH_SEARCH_ENABLED`/`LAGO_MEILISEARCH_API_KEY`
-# block is otherwise unrendered).
-meilisearch:
-  # -- Value projected into `LAGO_MEILISEARCH_SEARCH_ENABLED` on this
-  # workload's pods. Defaults to `true`; set to `false` to keep the
-  # URL + API key wired (so meili-adjacent code paths still work) but
-  # disable search itself on this specific workload — useful e.g. to
-  # stop the api from querying Meilisearch while the worker keeps
-  # indexing during a heavy backfill.
-  # @section -- Meilisearch
-  searchEnabled: true
 
 service:
   # -- Create a Service

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -238,15 +238,11 @@ global:
     # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
     # @section -- Meilisearch
     enabled: false
-    # -- Value projected into `LAGO_MEILISEARCH_SEARCH_ENABLED` on
-    # every Rails workload. Defaults to `true`; set to `false` to
-    # keep the URL + API key wired (so indexing paths still work)
-    # but stop the api from serving search queries against
-    # Meilisearch — e.g. during a heavy backfill when search
-    # timeouts are amplifying load. Only takes effect when
-    # `enabled` is true (otherwise the whole env block is elided).
+    # -- Projected as `LAGO_MEILISEARCH_SEARCH_ENABLED`. Set to
+    # `false` to stop serving search queries while keeping indexing
+    # wired (URL + API key unchanged).
     # @section -- Meilisearch
-    searchEnabled: true
+    search: true
     # -- Meilisearch endpoint URL (e.g.
     # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
     # @section -- Meilisearch

--- a/charts/lago-rails/values.yaml
+++ b/charts/lago-rails/values.yaml
@@ -527,6 +527,20 @@ extraEnvFrom: []
   # - secretRef:
   #     name: secret-name
 
+# Per-workload Meilisearch settings (only take effect when
+# `global.meilisearch.enabled` is true — the whole
+# `LAGO_MEILISEARCH_URL`/`LAGO_MEILISEARCH_SEARCH_ENABLED`/`LAGO_MEILISEARCH_API_KEY`
+# block is otherwise unrendered).
+meilisearch:
+  # -- Value projected into `LAGO_MEILISEARCH_SEARCH_ENABLED` on this
+  # workload's pods. Defaults to `true`; set to `false` to keep the
+  # URL + API key wired (so meili-adjacent code paths still work) but
+  # disable search itself on this specific workload — useful e.g. to
+  # stop the api from querying Meilisearch while the worker keeps
+  # indexing during a heavy backfill.
+  # @section -- Meilisearch
+  searchEnabled: true
+
 service:
   # -- Create a Service
   # @section -- Service

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -296,15 +296,11 @@ global:
     # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
     # @section -- Meilisearch
     enabled: false
-    # -- Value projected into `LAGO_MEILISEARCH_SEARCH_ENABLED` on
-    # every Rails workload. Defaults to `true`; set to `false` to
-    # keep the URL + API key wired (so indexing paths still work)
-    # but stop the api from serving search queries against
-    # Meilisearch — e.g. during a heavy backfill when search
-    # timeouts are amplifying load. Only takes effect when
-    # `enabled` is true (otherwise the whole env block is elided).
+    # -- Projected as `LAGO_MEILISEARCH_SEARCH_ENABLED`. Set to
+    # `false` to stop serving search queries while keeping indexing
+    # wired (URL + API key unchanged).
     # @section -- Meilisearch
-    searchEnabled: true
+    search: true
     # -- Meilisearch endpoint URL (e.g.
     # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
     # @section -- Meilisearch

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -296,6 +296,15 @@ global:
     # `LAGO_MEILISEARCH_API_KEY` on every Rails workload.
     # @section -- Meilisearch
     enabled: false
+    # -- Value projected into `LAGO_MEILISEARCH_SEARCH_ENABLED` on
+    # every Rails workload. Defaults to `true`; set to `false` to
+    # keep the URL + API key wired (so indexing paths still work)
+    # but stop the api from serving search queries against
+    # Meilisearch — e.g. during a heavy backfill when search
+    # timeouts are amplifying load. Only takes effect when
+    # `enabled` is true (otherwise the whole env block is elided).
+    # @section -- Meilisearch
+    searchEnabled: true
     # -- Meilisearch endpoint URL (e.g.
     # `http://meilisearch.meilisearch.svc.cluster.local:7700`).
     # @section -- Meilisearch


### PR DESCRIPTION
## What

Adds `global.meilisearch.search` (default `true`) to drive the `LAGO_MEILISEARCH_SEARCH_ENABLED` env — previously hardcoded to `"true"`. Sits alongside the existing `enabled` / `url` / `apiKey`. Default preserves current behavior exactly.

```yaml
# charts/lago-rails/templates/deployment.yaml
{{- if .Values.global.meilisearch.enabled }}
- name: LAGO_MEILISEARCH_URL
  valueFrom: { configMapKeyRef: { name: ..., key: meilisearch.endpoint } }
- name: LAGO_MEILISEARCH_SEARCH_ENABLED
- value: "true"                                              # ← removed
+ value: {{ .Values.global.meilisearch.search | quote }}     # ← new
- name: LAGO_MEILISEARCH_API_KEY
  valueFrom: { secretKeyRef: { name: ..., key: meilisearch.apiKey } }
{{- end }}
```

```yaml
# charts/lago-rails/values.yaml   (and mirrored in charts/lago/values.yaml)
global:
  meilisearch:
    enabled: false
    # Projected as LAGO_MEILISEARCH_SEARCH_ENABLED. Set to false to stop
    # serving search queries while keeping indexing wired.
    search: true
    url:
    apiKey:
```

## Why

Lets consumers disable Meilisearch *search* while keeping *indexing* alive — the standard mitigation during a heavy Meilisearch backfill when the api's search-side jobs time out (`Meilisearch::TimeoutError`), Sidekiq retries them, and the retries amplify load on an already-saturated Meilisearch.

### Why `extraEnv:` doesn't work

Under Server-Side Apply (argocd's default), duplicate `name` entries on a container's env list are rejected by the API server:
```
spec.template.spec.containers[0].env[N].name: Duplicate value: "LAGO_MEILISEARCH_SEARCH_ENABLED"
```
The chart's env block is still emitted (guarded by `global.meilisearch.enabled`), so a consumer's `extraEnv:` addition collides and the argocd sync fails. The override has to live in the chart.

## Consumer usage

Default (behaves exactly like today):
```yaml
global:
  meilisearch: { enabled: true, url: ..., apiKey: ... }
```

Disable search (URL + API key stay wired so indexing paths keep working):
```yaml
global:
  meilisearch:
    enabled: true
    search: false
    url: ...
    apiKey: ...
```

## Tests

Adds `charts/lago-rails/tests/meilisearch_search_enabled_test.yaml` (helm-unittest):
- default → projects `"true"`
- `global.meilisearch.search: false` → projects `"false"`
- URL + API_KEY stay projected when `search: false`
- `global.meilisearch.enabled: false` elides the whole block regardless of `search`

`helm unittest charts/lago-rails` → 11 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)