### PR TITLE
feat(lago): add worker-arm64 subchart for the Graviton pilot

### DIFF
--- a/charts/lago/Chart.lock
+++ b/charts/lago/Chart.lock
@@ -29,6 +29,9 @@ dependencies:
 - name: lago-rails
   repository: file://../lago-rails
   version: 0.10.0
+- name: lago-rails
+  repository: file://../lago-rails
+  version: 0.10.0
 - name: lago-pdf
   repository: file://../lago-pdf
   version: 0.10.0
@@ -56,5 +59,5 @@ dependencies:
 - name: lago-rails
   repository: file://../lago-rails
   version: 0.10.0
-digest: sha256:d7709d8e8de47577d030c94a01339805506c63d203d77e120db89b91489b49e2
-generated: "2026-08-13T08:47:33.990668342Z"
+digest: sha256:362f12a2020ca3b60c2bd832de536c7861547b9b81c88aa6a180ded49b80cd12
+generated: "2026-08-26T16:29:47.163824755+03:00"

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -36,6 +36,11 @@ dependencies:
     version: 0.10.0
     repository: "file://../lago-rails"
   - name: lago-rails
+    alias: worker-arm64
+    version: 0.10.0
+    repository: "file://../lago-rails"
+    condition: global.arm64.enabled
+  - name: lago-rails
     alias: clock
     version: 0.10.0
     repository: "file://../lago-rails"

--- a/charts/lago/tests/worker_arm64_test.yaml
+++ b/charts/lago/tests/worker_arm64_test.yaml
@@ -1,0 +1,76 @@
+suite: Test worker-arm64 subchart mirrors worker's shape via the shared YAML
+  anchor and only differs in scheduling (nodeSelector/tolerations/replicas).
+  global.arm64.enabled gates the subchart at the dependency level (verified
+  manually via `helm template` with the flag unset — a disabled conditional
+  dependency isn't selectable as a test template).
+templates:
+  - charts/worker/templates/deployment.yaml
+  - charts/worker-arm64/templates/deployment.yaml
+
+set:
+  global:
+    lago:
+      env: production
+      version: v1.0.0
+    urls:
+      api: http://api.test
+      front: http://front.test
+    database:
+      uri: postgresql://localhost
+    encryption:
+      key: test-key
+      salt: test-salt
+    signing:
+      hmac: test-hmac
+      rsa: test-rsa
+    redis:
+      uri: redis://localhost
+    redisCache:
+      uri: redis://localhost
+    redisStore:
+      uri: redis://localhost
+    arm64:
+      enabled: true
+
+tests:
+  - it: renders worker-arm64 with the same start script as worker
+    template: charts/worker-arm64/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lago-worker-arm64
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["./scripts/start.worker.sh"]
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: pins worker-arm64 to arm64 nodes via nodeSelector and a matching toleration
+    template: charts/worker-arm64/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            arch: arm64
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: arch
+            operator: Equal
+            value: arm64
+            effect: NoSchedule
+
+  - it: leaves worker unaffected — same command, no arm64 scheduling fields
+    template: charts/worker/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lago-worker
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["./scripts/start.worker.sh"]
+      - notExists:
+          path: spec.template.spec.nodeSelector
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -22,6 +22,16 @@ global:
     # @section -- Lago
     pdfGeneration: false
 
+  # -- arm64 (Graviton) migration pilot. Gates the `worker-arm64` subchart —
+  # a second copy of the default Sidekiq worker, pinned to arm64 nodes via
+  # its own nodeSelector/tolerations, run side-by-side with `worker` for
+  # comparison. Off by default so bumping this chart's version is a no-op on
+  # any cluster without an arm64 nodepool (the pod would otherwise sit
+  # Pending forever with no schedulable node).
+  # @section -- Arm64 Pilot
+  arm64:
+    enabled: false
+
   sidekiq:
     # -- Enable Sidekiq Pro (requires valid license)
     # @section -- Sidekiq
@@ -443,7 +453,7 @@ front:
 # -- Default Sidekiq worker subchart overrides (lago-rails)
 # @default -- See child values
 # @section -- Default Worker
-worker:
+worker: &workerDefaults
   # -- Override the worker subchart release name
   # @section -- Default Worker
   nameOverride: lago-worker
@@ -476,6 +486,35 @@ worker:
     # -- Worker container ports (none needed)
     # @section -- Default Worker
     ports: []
+
+# -- arm64 pilot subchart overrides (lago-rails, conditional on
+# `global.arm64.enabled`). Same queue/command as `worker` — a second,
+# separate Deployment pinned to arm64 nodes for side-by-side comparison, not
+# a new queue type — so it merges `worker`'s defaults via YAML anchor
+# instead of repeating them, and only overrides what actually differs:
+# release name, replica count, and scheduling.
+# @default -- See child values
+# @section -- Arm64 Pilot Worker
+worker-arm64:
+  <<: *workerDefaults
+  # -- Override the worker-arm64 subchart release name
+  # @section -- Arm64 Pilot Worker
+  nameOverride: lago-worker-arm64
+  # -- Single replica for the pilot — scaled up manually once the baseline
+  # watch window is clean.
+  # @section -- Arm64 Pilot Worker
+  replicaCount: 1
+  # -- Pin to the arm64 Karpenter nodepool's label.
+  # @section -- Arm64 Pilot Worker
+  nodeSelector:
+    arch: arm64
+  # -- Match the arm64 nodepool's taint so only this deployment schedules there.
+  # @section -- Arm64 Pilot Worker
+  tolerations:
+    - key: arch
+      operator: Equal
+      value: arm64
+      effect: NoSchedule
 
 # -- Clock scheduler subchart overrides (lago-rails)
 # @default -- See child values


### PR DESCRIPTION
## Summary
- Adds a `worker-arm64` subchart (alias of `lago-rails`) for [INF-375](https://linear.app/getlago/issue/INF-375/migrate-workers-to-graviton-dev-us) — the dev-us-1 pilot of the Graviton worker migration. Gated by `global.arm64.enabled` (default `false`), so this is a no-op for every cluster until a values file opts in.
- `worker-arm64` merges `worker`'s existing values through a YAML anchor (`&workerDefaults` / `<<: *workerDefaults`) instead of duplicating the block, since the two are identical except for release name, replica count, and scheduling. This differs from the other named workers in this chart (`billing-worker`, `wallets-worker`, etc.), which each have a genuinely different container command.
- `nodeSelector`/`tolerations` match the arm64 Karpenter nodepool taint and label added in `lago-infrastructure` PR #1595 (`arch: arm64`, `NoSchedule`).
- `Chart.lock` regenerated via `helm dependency update`. Chart versions are intentionally not bumped — `release.sh`'s `bump_versions` step does that automatically when the release is dispatched.

## Known limitation
`helm-docs` doesn't render the YAML-anchor merge correctly — it emits `worker-arm64.<<.*` rows carrying `worker`'s stale defaults. I left `README.md` unregenerated rather than commit misleading docs; happy to hand-write a clean `worker-arm64` doc block if that's wanted before merge.

## Test plan
- [x] `helm unittest charts/lago` — 7 suites / 54 tests pass, including the new `tests/worker_arm64_test.yaml`.
- [x] `helm template` with `global.arm64.enabled=true` — `worker-arm64` renders with the same command/env as `worker`, plus `replicas: 1`, `nodeSelector: {arch: arm64}`, and the matching toleration.
- [x] `helm template` with the flag unset (default) — zero `worker-arm64` resources render.
- [ ] After merge + a `workflow_dispatch` release: wire `global.arm64.enabled: true` and a `worker-arm64` override into `lago-deploy`'s dev-us-1 `main` preview values, confirm the pod schedules onto an arm64 node and reaches `Ready`.
