### PR TITLE
feat(lago): add GCS support and stop provisioning the local PVC for it

### DIFF
--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.32.4"
 description: the Lago open source billing app
 name: lago
-version: 1.28.0
+version: 1.29.0
 dependencies:
   - name: minio
     version: "5.2.0"

--- a/charts/lago/templates/_helpers.tpl
+++ b/charts/lago/templates/_helpers.tpl
@@ -85,3 +85,34 @@
       key: clickhousePassword
       optional: true
 {{- end }}
+
+{{- define "gcsEnvs" }}
+{{- $gcs := .Values.global.gcs -}}
+- name: LAGO_USE_GCS
+  value: "true"
+- name: LAGO_GCS_PROJECT
+  value: {{ required "If gcs is enabled, you must provide global.gcs.project" $gcs.project | quote }}
+- name: LAGO_GCS_BUCKET
+  value: {{ required "If gcs is enabled, you must provide global.gcs.bucket" $gcs.bucket | quote }}
+{{- if $gcs.iam }}
+- name: LAGO_GCS_IAM
+  value: "true"
+- name: LAGO_GCS_GSA_EMAIL
+  value: {{ required "If gcs iam is enabled, you must provide global.gcs.gsaEmail" $gcs.gsaEmail | quote }}
+{{- end }}
+{{- with $gcs.keyfileJsonPath }}
+- name: LAGO_GCS_KEYFILE_JSON_PATH
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Renders "true" when no object storage backend is configured, meaning the chart
+has to provision and mount its bundled local-storage PersistentVolumeClaim.
+Empty (falsy) otherwise, so it can be used as {{ if include "localStorage" . }}.
+*/}}
+{{- define "localStorage" -}}
+{{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) (not .Values.global.gcs.enabled) -}}
+true
+{{- end -}}
+{{- end }}

--- a/charts/lago/templates/api-deployment.yaml
+++ b/charts/lago/templates/api-deployment.yaml
@@ -200,6 +200,9 @@ spec:
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}
           {{ end }}
+            {{- if .Values.global.gcs.enabled }}
+            {{- include "gcsEnvs" . | nindent 12 }}
+            {{- end }}
             {{ if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL
               value: {{ .Values.global.smtp.fromEmail }}
@@ -265,13 +268,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+          {{- if include "localStorage" . }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+      {{- if include "localStorage" . }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/charts/lago/templates/billing-worker-deployment.yaml
+++ b/charts/lago/templates/billing-worker-deployment.yaml
@@ -182,6 +182,9 @@ spec:
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}
             {{ end }}
+            {{- if .Values.global.gcs.enabled }}
+            {{- include "gcsEnvs" . | nindent 12 }}
+            {{- end }}
 
             {{ if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL
@@ -224,13 +227,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+          {{ if include "localStorage" . }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+      {{ if include "localStorage" . }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/charts/lago/templates/clock-worker-deployment.yaml
+++ b/charts/lago/templates/clock-worker-deployment.yaml
@@ -182,6 +182,9 @@ spec:
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}
             {{ end }}
+            {{- if .Values.global.gcs.enabled }}
+            {{- include "gcsEnvs" . | nindent 12 }}
+            {{- end }}
 
             {{ if .Values.global.newRelic.enabled }}
             - name: NEW_RELIC_KEY
@@ -206,13 +209,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+          {{ if include "localStorage" . }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+      {{ if include "localStorage" . }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/charts/lago/templates/payment-worker-deployment.yaml
+++ b/charts/lago/templates/payment-worker-deployment.yaml
@@ -182,6 +182,9 @@ spec:
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}
             {{ end }}
+            {{- if .Values.global.gcs.enabled }}
+            {{- include "gcsEnvs" . | nindent 12 }}
+            {{- end }}
 
             {{ if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL
@@ -224,13 +227,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+          {{ if include "localStorage" . }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+      {{ if include "localStorage" . }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/charts/lago/templates/pdf-worker-deployment.yaml
+++ b/charts/lago/templates/pdf-worker-deployment.yaml
@@ -182,6 +182,9 @@ spec:
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}
             {{ end }}
+            {{- if .Values.global.gcs.enabled }}
+            {{- include "gcsEnvs" . | nindent 12 }}
+            {{- end }}
 
             {{ if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL
@@ -224,13 +227,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+          {{ if include "localStorage" . }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+      {{ if include "localStorage" . }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/charts/lago/templates/storage-data-persistentvolumeclaim.yaml
+++ b/charts/lago/templates/storage-data-persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
+{{- if include "localStorage" . -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/lago/templates/worker-deployment.yaml
+++ b/charts/lago/templates/worker-deployment.yaml
@@ -181,6 +181,9 @@ spec:
                         {{ default "us-east-1" .Values.minio.region | quote }}
                       {{ end }}
             {{ end }}
+            {{- if .Values.global.gcs.enabled }}
+            {{- include "gcsEnvs" . | nindent 12 }}
+            {{- end }}
 
             {{ if .Values.global.smtp.enabled }}
             - name: LAGO_FROM_EMAIL
@@ -223,13 +226,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12}}
           {{- end }}
-          {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+          {{ if include "localStorage" . }}
           volumeMounts:
             - mountPath: /app/storage
               name: {{ .Release.Name }}-storage-data
           {{ end }}
       restartPolicy: Always
-      {{ if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) }}
+      {{ if include "localStorage" . }}
       volumes:
         - name: {{ .Release.Name }}-storage-data
           persistentVolumeClaim:

--- a/charts/lago/tests/storage_test.yaml
+++ b/charts/lago/tests/storage_test.yaml
@@ -1,0 +1,202 @@
+suite: Test object storage backends and the bundled local-storage volume
+templates:
+  - templates/storage-data-persistentvolumeclaim.yaml
+  - templates/api-deployment.yaml
+  - templates/worker-deployment.yaml
+  - templates/billing-worker-deployment.yaml
+  - templates/payment-worker-deployment.yaml
+  - templates/pdf-worker-deployment.yaml
+  - templates/clock-worker-deployment.yaml
+
+set:
+  apiUrl: "api.lago.dev"
+  frontUrl: "front.lago.dev"
+  billingWorker.enabled: true
+  paymentWorker.enabled: true
+  pdfWorker.enabled: true
+  clockWorker.enabled: true
+
+tests:
+  - it: should provision the local storage claim when no object storage is configured
+    template: templates/storage-data-persistentvolumeclaim.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: RELEASE-NAME-storage-data
+
+  - it: should mount the local storage claim in every storage aware workload by default
+    documentSelector:
+      path: kind
+      value: Deployment
+      matchMany: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-storage-data
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-storage-data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /app/storage
+            name: RELEASE-NAME-storage-data
+
+  - it: should not provision the local storage claim when gcs is enabled
+    template: templates/storage-data-persistentvolumeclaim.yaml
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+      global.gcs.bucket: "lago-bucket"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not mount the local storage claim in any workload when gcs is enabled
+    documentSelector:
+      path: kind
+      value: Deployment
+      matchMany: true
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+      global.gcs.bucket: "lago-bucket"
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: should not provision the local storage claim when s3 is enabled
+    template: templates/storage-data-persistentvolumeclaim.yaml
+    set:
+      global.s3.enabled: true
+      global.s3.bucket: "lago-bucket"
+      global.s3.region: "eu-west-1"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not provision the local storage claim when minio is enabled
+    template: templates/storage-data-persistentvolumeclaim.yaml
+    set:
+      minio.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should wire the gcs environment in every storage aware workload
+    documentSelector:
+      path: kind
+      value: Deployment
+      matchMany: true
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+      global.gcs.bucket: "lago-bucket"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_USE_GCS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_GCS_PROJECT
+            value: "lago-project"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_GCS_BUCKET
+            value: "lago-bucket"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_USE_AWS_S3
+            value: "true"
+
+  - it: should use workload identity when gcs iam is enabled
+    template: templates/api-deployment.yaml
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+      global.gcs.bucket: "lago-bucket"
+      global.gcs.iam: true
+      global.gcs.gsaEmail: "lago@lago-project.iam.gserviceaccount.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_GCS_IAM
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_GCS_GSA_EMAIL
+            value: "lago@lago-project.iam.gserviceaccount.com"
+
+  - it: should pass the keyfile path when workload identity is not used
+    template: templates/api-deployment.yaml
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+      global.gcs.bucket: "lago-bucket"
+      global.gcs.keyfileJsonPath: "/etc/gcs/keyfile.json"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_GCS_KEYFILE_JSON_PATH
+            value: "/etc/gcs/keyfile.json"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_GCS_IAM
+            value: "true"
+
+  - it: should not emit any gcs environment by default
+    template: templates/api-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LAGO_USE_GCS
+            value: "true"
+
+  - it: should require a project when gcs is enabled
+    # helm renders templates in reverse alphabetical order, so the required
+    # value is reported against the last of the storage aware deployments
+    template: templates/worker-deployment.yaml
+    set:
+      global.gcs.enabled: true
+      global.gcs.bucket: "lago-bucket"
+    asserts:
+      - failedTemplate:
+          errorMessage: "If gcs is enabled, you must provide global.gcs.project"
+
+  - it: should require a bucket when gcs is enabled
+    # helm renders templates in reverse alphabetical order, so the required
+    # value is reported against the last of the storage aware deployments
+    template: templates/worker-deployment.yaml
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+    asserts:
+      - failedTemplate:
+          errorMessage: "If gcs is enabled, you must provide global.gcs.bucket"
+
+  - it: should require a service account email when gcs iam is enabled
+    # helm renders templates in reverse alphabetical order, so the required
+    # value is reported against the last of the storage aware deployments
+    template: templates/worker-deployment.yaml
+    set:
+      global.gcs.enabled: true
+      global.gcs.project: "lago-project"
+      global.gcs.bucket: "lago-bucket"
+      global.gcs.iam: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "If gcs iam is enabled, you must provide global.gcs.gsaEmail"

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -45,6 +45,24 @@ global:
     # region: "<your-aws-region>"
     # endpoint: "https://s3.<region>.amazonaws.com" # Leave empty for default AWS S3 endpoint
 
+  # Google Cloud Storage. Mutually exclusive with s3 and minio: when s3 is also
+  # enabled Lago falls back to S3, since LAGO_USE_AWS_S3 takes precedence.
+  gcs:
+    enabled: false
+    # project: "<your-gcp-project>"
+    # bucket: "<your-gcs-bucket>"
+    #
+    # Recommended on GKE: authenticate with Workload Identity instead of a keyfile.
+    # Set global.serviceAccountName to a ServiceAccount you have annotated with
+    # iam.gke.io/gcp-service-account, and point gsaEmail at the same Google service
+    # account so Lago can sign URLs through the IAM API.
+    # iam: true
+    # gsaEmail: "<service-account>@<your-gcp-project>.iam.gserviceaccount.com"
+    #
+    # Alternative: path to a service account keyfile. The chart does not mount the
+    # keyfile for you, so it has to already be present in the container at this path.
+    # keyfileJsonPath: "/etc/gcs/keyfile.json"
+
   smtp:
     # username and password are not required here if using existingSecret
     enabled: false


### PR DESCRIPTION
## Problem

The chart has no GCS support, and the bundled local-storage PVC is gated only on S3/MinIO:

```
{{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) -}}
```

For anyone running Lago against Google Cloud Storage that gate is always true, so the chart
creates one `ReadWriteOnce` PVC (`{{ .Release.Name }}-storage-data`) and mounts it at
`/app/storage` into six deployments: `api`, `worker`, `billing-worker`, `payment-worker`,
`pdf-worker` and `clock-worker`.

A single RWO PD attaches to one node, so all six pods have to co-locate. That happens by luck
on the first install; any subsequent rollout that lands a pod on another node deadlocks:

```
Warning  FailedAttachVolume  attachdetach-controller
Multi-Attach error for volume "pvc-bf9b665e-..." Volume is already used by pod(s)
lago-billing-worker-..., lago-pdf-worker-..., lago-clock-worker-...,
lago-payment-worker-..., lago-worker-..., lago-api-...
```

The volume is never read or written when object storage is active, so the outage is caused
entirely by a volume the deployment does not need.

`global.s3.enabled: true` is not a usable workaround for GCS users: the chart hardcodes
`LAGO_USE_AWS_S3: "true"`, which `config/environments/production.rb` checks *before*
`LAGO_USE_GCS`, and it injects `LAGO_AWS_S3_ACCESS_KEY_ID` from the `awsS3AccessKeyId`
secret key, which GCS users do not have (`CreateContainerConfigError`).

## What this PR does

1. **`global.gcs`** in `values.yaml`, mirroring the shape of `global.s3`:
   `enabled`, `project`, `bucket`, `iam`, `gsaEmail`, `keyfileJsonPath`. Defaults to
   `enabled: false`.

2. **A `gcsEnvs` helper**, following the existing `kafkaEnvs` / `clickhouseEnvs` pattern,
   emitting `LAGO_USE_GCS`, `LAGO_GCS_PROJECT`, `LAGO_GCS_BUCKET`, and optionally
   `LAGO_GCS_IAM` + `LAGO_GCS_GSA_EMAIL` (Workload Identity) or `LAGO_GCS_KEYFILE_JSON_PATH`.
   Names match `config/storage.yml` in `getlago/lago-api`.

3. **A `localStorage` helper** replacing the inline `and (not ...) (not ...)` gate in 13
   places, so the "is the bundled PVC needed?" question is answered once:

   ```
   {{- define "localStorage" -}}
   {{- if and (not .Values.global.s3.enabled) (not .Values.minio.enabled) (not .Values.global.gcs.enabled) -}}
   true
   {{- end -}}
   {{- end }}
   ```

4. **The gate applied** to `storage-data-persistentvolumeclaim.yaml` and to the `volumes:` /
   `volumeMounts:` blocks in the six deployments above, so enabling GCS stops provisioning
   and mounting the PVC entirely.

5. **`gcsEnvs` wired into** the same six deployments that already carry the S3 env block.

6. **`charts/lago/tests/storage_test.yaml`**, covering the PVC and mounts by default, their
   absence under `gcs`/`s3`/`minio`, the GCS env wiring, both auth paths, and the
   `required` guardrails.

## Backwards compatibility

Rendered output is unchanged for anyone who has not set `global.gcs.enabled`. Verified with a
before/after `helm template` diff across default, `global.s3.enabled=true`, `minio.enabled=true`,
`global.clickhouse.enabled=true` and `global.existingSecret` value sets: byte-identical once the
chart's inherent per-render nondeterminism (generated secrets, MinIO credentials,
`checksum/secrets`, Kafka topic ordering) is normalised.

`helm unittest ./charts/lago`: 22 tests, 4 suites, all passing.

## Deliberately out of scope

Two related gaps that this PR does not try to fix:

- Even for genuine local-storage users, one shared RWO PVC across six deployments cannot
  survive a rolling update on a multi-node cluster. Fixing that properly means either RWX,
  per-deployment volumes, or dropping the shared mount.
- The S3 env block is missing from `clock`, `events-worker` and `webhook-worker`, which also
  touch Active Storage. Those have the same gap for both S3 and GCS.
- `keyfileJsonPath` is exposed for parity with the app's env, but the chart has no
  `extraVolumes` support, so the keyfile has to already be present in the container. Workload
  Identity (`iam: true`) is the practical path on GKE and needs no mounted file.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
