### PR TITLE
feat(lago): add api-arm64 subchart for Graviton

### DIFF
--- a/charts/lago/Chart.lock
+++ b/charts/lago/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: lago-rails
   repository: file://../lago-rails
   version: 0.11.0
+- name: lago-rails
+  repository: file://../lago-rails
+  version: 0.11.0
 - name: lago-front
   repository: file://../lago-front
   version: 0.11.0
@@ -59,5 +62,5 @@ dependencies:
 - name: lago-rails
   repository: file://../lago-rails
   version: 0.11.0
-digest: sha256:84d939cca1ea14a2f728090e2cb9b142e7161b82f85ef0d3997ec8c035d7527b
-generated: "2026-08-26T15:50:29.864606422Z"
+digest: sha256:ce2cdada8770b530be84636e6a58c117e3b73a9f4894533d7d9c3ef8f4e7876f
+generated: "2026-08-28T14:11:56.639766979+03:00"

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -27,6 +27,11 @@ dependencies:
     alias: api
     version: 0.11.0
     repository: "file://../lago-rails"
+  - name: lago-rails
+    alias: api-arm64
+    version: 0.11.0
+    repository: "file://../lago-rails"
+    condition: global.arm64.api.enabled
   - name: lago-front
     alias: front
     version: 0.11.0
@@ -39,7 +44,7 @@ dependencies:
     alias: worker-arm64
     version: 0.11.0
     repository: "file://../lago-rails"
-    condition: global.arm64.enabled
+    condition: global.arm64.worker.enabled
   - name: lago-rails
     alias: clock
     version: 0.11.0

--- a/charts/lago/tests/api_arm64_test.yaml
+++ b/charts/lago/tests/api_arm64_test.yaml
@@ -1,11 +1,11 @@
-suite: Test worker-arm64 subchart mirrors worker's shape via the shared YAML
-  anchor and only differs in scheduling (nodeSelector/tolerations/replicas).
-  global.arm64.worker.enabled gates the subchart at the dependency level
-  (verified manually via `helm template` with the flag unset — a disabled
-  conditional dependency isn't selectable as a test template).
+suite: Test api-arm64 subchart mirrors api's shape via the shared YAML anchor
+  and only differs in scheduling (nodeSelector/tolerations/replicas).
+  global.arm64.api.enabled gates the subchart at the dependency level (verified
+  manually via `helm template` with the flag unset — a disabled conditional
+  dependency isn't selectable as a test template).
 templates:
-  - charts/worker/templates/deployment.yaml
-  - charts/worker-arm64/templates/deployment.yaml
+  - charts/api/templates/deployment.yaml
+  - charts/api-arm64/templates/deployment.yaml
 
 set:
   global:
@@ -30,25 +30,25 @@ set:
     redisStore:
       uri: redis://localhost
     arm64:
-      worker:
+      api:
         enabled: true
 
 tests:
-  - it: renders worker-arm64 with the same start script as worker
-    template: charts/worker-arm64/templates/deployment.yaml
+  - it: renders api-arm64 with the same start script as api
+    template: charts/api-arm64/templates/deployment.yaml
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-lago-worker-arm64
+          value: RELEASE-NAME-lago-api-arm64
       - equal:
           path: spec.template.spec.containers[0].command
-          value: ["./scripts/start.worker.sh"]
+          value: ["./scripts/start.api.sh"]
       - equal:
           path: spec.replicas
           value: 1
 
-  - it: pins worker-arm64 to arm64 nodes via nodeSelector and a matching toleration
-    template: charts/worker-arm64/templates/deployment.yaml
+  - it: pins api-arm64 to arm64 nodes via nodeSelector and a matching toleration
+    template: charts/api-arm64/templates/deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector
@@ -62,15 +62,15 @@ tests:
             value: arm64
             effect: NoSchedule
 
-  - it: leaves worker unaffected — same command, no arm64 scheduling fields
-    template: charts/worker/templates/deployment.yaml
+  - it: leaves api unaffected — same command, no arm64 scheduling fields
+    template: charts/api/templates/deployment.yaml
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-lago-worker
+          value: RELEASE-NAME-lago-api
       - equal:
           path: spec.template.spec.containers[0].command
-          value: ["./scripts/start.worker.sh"]
+          value: ["./scripts/start.api.sh"]
       - notExists:
           path: spec.template.spec.nodeSelector
       - notExists:

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -22,15 +22,24 @@ global:
     # @section -- Lago
     pdfGeneration: false
 
-  # -- arm64 (Graviton) migration pilot. Gates the `worker-arm64` subchart —
-  # a second copy of the default Sidekiq worker, pinned to arm64 nodes via
-  # its own nodeSelector/tolerations, run side-by-side with `worker` for
-  # comparison. Off by default so bumping this chart's version is a no-op on
-  # any cluster without an arm64 nodepool (the pod would otherwise sit
-  # Pending forever with no schedulable node).
+  # -- arm64 (Graviton) migration pilot. Each flag gates a second copy of a
+  # workload (`worker-arm64` / `api-arm64`), pinned to arm64 nodes via its own
+  # nodeSelector/tolerations and run side-by-side with the amd64 original for
+  # comparison. The worker and api flags are independent so the two migrations
+  # can be phased separately (workers first, then the API). Both off by default
+  # so bumping this chart's version is a no-op on any cluster without an arm64
+  # nodepool (the pod would otherwise sit Pending forever with no schedulable
+  # node).
   # @section -- Arm64 Pilot
   arm64:
-    enabled: false
+    # -- Gate the `worker-arm64` subchart (a Sidekiq worker on arm64 nodes).
+    # @section -- Arm64 Pilot
+    worker:
+      enabled: false
+    # -- Gate the `api-arm64` subchart (an API replica on arm64 nodes).
+    # @section -- Arm64 Pilot
+    api:
+      enabled: false
 
   sidekiq:
     # -- Enable Sidekiq Pro (requires valid license)
@@ -420,7 +429,7 @@ config:
 # -- lago-api subchart overrides (lago-rails)
 # @default -- See child values
 # @section -- API
-api:
+api: &apiDefaults
   config:
     # -- Disable nested config (uses parent config subchart)
     # @section -- API
@@ -436,6 +445,36 @@ api:
   # -- Override the API subchart release name
   # @section -- API
   nameOverride: lago-api
+
+# -- arm64 pilot subchart overrides (lago-rails, conditional on
+# `global.arm64.api.enabled`). Same image/command as `api` — a second,
+# separate API Deployment pinned to arm64 nodes for side-by-side comparison —
+# so it merges `api`'s defaults via YAML anchor instead of repeating them, and
+# only overrides what actually differs: release name, replica count, and
+# scheduling. Its own Service comes with the subchart, so the pilot can be
+# health-checked directly without touching the amd64 api's traffic.
+# @default -- See child values
+# @section -- Arm64 Pilot API
+api-arm64:
+  <<: *apiDefaults
+  # -- Override the api-arm64 subchart release name
+  # @section -- Arm64 Pilot API
+  nameOverride: lago-api-arm64
+  # -- Single replica for the pilot — scaled up manually once the baseline
+  # watch window is clean.
+  # @section -- Arm64 Pilot API
+  replicaCount: 1
+  # -- Pin to the arm64 Karpenter nodepool's label.
+  # @section -- Arm64 Pilot API
+  nodeSelector:
+    arch: arm64
+  # -- Match the arm64 nodepool's taint so only this deployment schedules there.
+  # @section -- Arm64 Pilot API
+  tolerations:
+    - key: arch
+      operator: Equal
+      value: arm64
+      effect: NoSchedule
 
 # -- lago-front subchart overrides
 # @default -- See child values
@@ -488,7 +527,7 @@ worker: &workerDefaults
     ports: []
 
 # -- arm64 pilot subchart overrides (lago-rails, conditional on
-# `global.arm64.enabled`). Same queue/command as `worker` — a second,
+# `global.arm64.worker.enabled`). Same queue/command as `worker` — a second,
 # separate Deployment pinned to arm64 nodes for side-by-side comparison, not
 # a new queue type — so it merges `worker`'s defaults via YAML anchor
 # instead of repeating them, and only overrides what actually differs:


### PR DESCRIPTION
## What

Adds an `api-arm64` subchart to `charts/lago` for the Graviton (arm64)
API migration pilot (INF-379). It mirrors the `worker-arm64` alias from
INF-375.

- New `lago-rails` alias `api-arm64`, gated by `global.arm64.api.enabled`
  (default false).
- Merges `api`'s shape via a YAML anchor. Overrides only
  `nameOverride: lago-api-arm64`, `replicaCount: 1`, and the arm64
  `nodeSelector` + toleration.
- It keeps its own Service, so the pilot can be health-checked directly.

## Breaking change

The worker gate `global.arm64.enabled` is renamed to
`global.arm64.worker.enabled`. The worker and API migrations now phase
independently. Any consumer of the old flag must move to the new name.
The only current consumer is dev-us-1, updated in the paired lago-deploy
PR.

## Verification

- `helm unittest charts/lago` — 57 tests pass (new `api_arm64_test.yaml`;
  `worker_arm64_test.yaml` updated to the new gate name).
- `helm template`: both gates off by default render zero arm64 resources.
  The old `global.arm64.enabled` flag no longer triggers worker-arm64.

## Notes

Chart versions are not bumped here. `release.sh` bumps them when the
release is cut (→ `0.12.0`). The lago-deploy pin waits for that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
