### PR TITLE
chore: Remove meilisearch

### DIFF
--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -84,11 +84,6 @@ dependencies:
     version: 0.6.0
     repository: "file://../lago-events-processor-worker"
     condition: global.streaming_ingestion.enabled
-  - name: lago-rails
-    alias: meilisearch-worker
-    version: 0.6.0
-    repository: "file://../lago-rails"
-    condition: global.sidekiq.queues.meilisearch
 
 annotations:
   org.opencontainers.image.source: "https://github.com/getlago/lago-helm-charts"

--- a/charts/lago/README.md
+++ b/charts/lago/README.md
@@ -22,7 +22,6 @@ A Helm chart for Kubernetes
 | file://../lago-rails | pdf-worker(lago-rails) | 0.5.19 |
 | file://../lago-rails | events-consumer-worker(lago-rails) | 0.5.19 |
 | file://../lago-rails | api(lago-rails) | 0.5.19 |
-| file://../lago-rails | meilisearch-worker(lago-rails) | 0.5.19 |
 
 ## Values
 
@@ -206,20 +205,6 @@ A Helm chart for Kubernetes
 | front | object | See child values | lago-front subchart overrides |
 | front.config.enabled | bool | `false` | Disable nested config |
 | front.nameOverride | string | `"lago-front"` | Override the front subchart release name |
-
-### Meilisearch Worker
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| meilisearch-worker | object | See child values | Meilisearch worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.meilisearch`) |
-| meilisearch-worker.config.enabled | bool | `false` | Disable nested config (uses parent config subchart) |
-| meilisearch-worker.config.nameOverride | string | `"lago-config"` | Config subchart name override |
-| meilisearch-worker.container.command | list | `["./scripts/start.meilisearch.worker.sh"]` | Meilisearch worker entrypoint command |
-| meilisearch-worker.container.ports | list | `[]` | Container ports (none needed) |
-| meilisearch-worker.livenessProbe | object | `{"enabled":false}` | Liveness probe (disabled for workers) |
-| meilisearch-worker.nameOverride | string | `"lago-meilisearch-worker"` | Override the meilisearch-worker subchart release name |
-| meilisearch-worker.readinessProbe | object | `{"enabled":false}` | Readiness probe (disabled for workers) |
-| meilisearch-worker.service.enabled | bool | `false` | Disable service (no inbound traffic) |
 
 ### Database Migration
 

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -45,9 +45,6 @@ global:
       # -- Enable the PDF background queue
       # @section -- Sidekiq
       pdf: false
-      # -- Enable the Meilisearch indexing queue
-      # @section -- Sidekiq
-      meilisearch: false
 
   config:
     # -- Name of an existing ConfigMap for shared configuration (bypasses auto-generated configmap)
@@ -541,40 +538,6 @@ billing-worker:
     command: ["./scripts/start.billing.worker.sh"]
     # -- Container ports (none needed)
     # @section -- Billing Worker
-    ports: []
-
-# -- Meilisearch worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.meilisearch`)
-# @default -- See child values
-# @section -- Meilisearch Worker
-meilisearch-worker:
-  # -- Override the meilisearch-worker subchart release name
-  # @section -- Meilisearch Worker
-  nameOverride: lago-meilisearch-worker
-  config:
-    # -- Disable nested config (uses parent config subchart)
-    # @section -- Meilisearch Worker
-    enabled: false
-    # -- Config subchart name override
-    # @section -- Meilisearch Worker
-    nameOverride: lago-config
-  # -- Liveness probe (disabled for workers)
-  # @section -- Meilisearch Worker
-  livenessProbe:
-    enabled: false
-  # -- Readiness probe (disabled for workers)
-  # @section -- Meilisearch Worker
-  readinessProbe:
-    enabled: false
-  service:
-    # -- Disable service (no inbound traffic)
-    # @section -- Meilisearch Worker
-    enabled: false
-  container:
-    # -- Meilisearch worker entrypoint command
-    # @section -- Meilisearch Worker
-    command: ["./scripts/start.meilisearch.worker.sh"]
-    # -- Container ports (none needed)
-    # @section -- Meilisearch Worker
     ports: []
 
 # -- Clock worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.clock`)


### PR DESCRIPTION
  ## Remove Meilisearch from the lago chart

  Meilisearch has been fully decommissioned across Lago infra (workers, server, PVCs, IAM, DNS, Zitadel OIDC — all torn down) and stripped from lago-infrastructure and lago-deploy. This removes the last of it: the dormant Meilisearch worker in the chart itself.

  ### Changes
  - `Chart.yaml` — drop the `meilisearch-worker` dependency (lago-rails alias gated on `global.sidekiq.queues.meilisearch`).
  - `values.yaml` — drop the `sidekiq.queues.meilisearch` toggle and the `meilisearch-worker` subchart overrides block.
  - `README.md` — drop the dependency-table row and the Meilisearch Worker section.

  ### Validation
  `helm lint` passes with 0 failures. `helm template` renders zero Meilisearch references — including when `global.sidekiq.queues.meilisearch=true` is forced, confirming the subchart is gone and can't be
  re-enabled by a stale value. The other 11 worker subcharts are unaffected.

  Chart version bump is left to the standard lockstep release chore (mirroring how the worker was originally added).