### PR TITLE
Add the streaming-worker subchart

### DIFF
--- a/charts/lago/Chart.lock
+++ b/charts/lago/Chart.lock
@@ -53,5 +53,8 @@ dependencies:
 - name: lago-rails
   repository: file://../lago-rails
   version: 0.14.0
-digest: sha256:f28e6bb3f6c1a348c55cafa01ffb0c47208fa80b4db9e0ed54c596aa3d4a0805
-generated: "2026-09-01T10:02:37.273184-07:00"
+- name: lago-rails
+  repository: file://../lago-rails
+  version: 0.14.0
+digest: sha256:2e13b2453479e1caccf7a2f39acf96d9b3f9f78f1f501b0ef22a876b63d2feaf
+generated: "2026-09-07T14:32:12.986316781+03:00"

--- a/charts/lago/Chart.yaml
+++ b/charts/lago/Chart.yaml
@@ -104,6 +104,11 @@ dependencies:
     version: 0.14.0
     repository: "file://../lago-rails"
     condition: global.sidekiq.queues.aiAgent
+  - name: lago-rails
+    alias: streaming-worker
+    version: 0.14.0
+    repository: "file://../lago-rails"
+    condition: global.sidekiq.queues.streaming
 
 annotations:
   org.opencontainers.image.source: "https://github.com/getlago/lago-helm-charts"

--- a/charts/lago/tests/streaming_worker_test.yaml
+++ b/charts/lago/tests/streaming_worker_test.yaml
@@ -1,0 +1,78 @@
+suite: Test streaming-worker subchart is gated by global.sidekiq.queues.streaming
+  and invokes the sidekiq_streaming.yml config via its dedicated start script.
+  Unlike the other queue toggles this one renders no enqueue-side env var,
+  because DeliverEventJob is pinned to the `streaming` queue with `queue_as`
+  and the enqueue gate is the organization's streaming_destinations row. The
+  worker also gets its own ServiceAccount, which is what carries the AWS
+  identity that assumes the destination role.
+templates:
+  - charts/streaming-worker/templates/deployment.yaml
+  - charts/streaming-worker/templates/serviceaccount.yaml
+
+set:
+  global:
+    lago:
+      env: production
+      version: v1.0.0
+    urls:
+      api: http://api.test
+      front: http://front.test
+    database:
+      uri: postgresql://localhost
+    encryption:
+      key: test-key
+      salt: test-salt
+    signing:
+      hmac: test-hmac
+      rsa: test-rsa
+    redis:
+      uri: redis://localhost
+    redisCache:
+      uri: redis://localhost
+    redisStore:
+      uri: redis://localhost
+
+tests:
+  - it: renders the streaming-worker deployment with its dedicated start script
+    template: charts/streaming-worker/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.streaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lago-streaming-worker
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["./scripts/start.streaming.worker.sh"]
+
+  - it: gives the worker its own ServiceAccount for the AWS identity
+    template: charts/streaming-worker/templates/serviceaccount.yaml
+    set:
+      global.sidekiq.queues.streaming: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-lago-streaming-worker
+
+  - it: binds the pods to an existing ServiceAccount when one is named
+    template: charts/streaming-worker/templates/deployment.yaml
+    set:
+      global.sidekiq.queues.streaming: true
+      streaming-worker.serviceAccount.create: false
+      streaming-worker.serviceAccount.name: kinesis-sandbox-publisher
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kinesis-sandbox-publisher
+
+  - it: renders no ServiceAccount of its own when one is named
+    template: charts/streaming-worker/templates/serviceaccount.yaml
+    set:
+      global.sidekiq.queues.streaming: true
+      streaming-worker.serviceAccount.create: false
+      streaming-worker.serviceAccount.name: kinesis-sandbox-publisher
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/lago/values.yaml
+++ b/charts/lago/values.yaml
@@ -67,6 +67,15 @@ global:
       # the `ai_agent` queue instead of `default`). Off by default.
       # @section -- Sidekiq
       aiAgent: false
+      # -- Enable the streaming worker (isolates the `streaming` Sidekiq queue
+      # on a separate deployment). `DeliverEventJob` is pinned to that queue
+      # with `queue_as :streaming`, so there is no enqueue-side env flag: the
+      # job is enqueued only for an organization that holds a
+      # `streaming_destinations` row. A cluster that runs no streaming worker
+      # therefore never fills the queue. The worker needs an AWS identity that
+      # can assume the destination role, so it is off by default.
+      # @section -- Sidekiq
+      streaming: false
       # -- Dedicated worker queue toggle. Unlike the other queue flags this
       # is a dict rather than a bool: the dedicated_alerts / dedicated_wallets
       # queues are populated by per-org routing decisions in
@@ -758,6 +767,47 @@ ai-agent-worker:
     command: ["./scripts/start.ai_agent.worker.sh"]
     # -- Container ports (none needed)
     # @section -- AI Agent Worker
+    ports: []
+
+# -- Streaming worker subchart overrides (lago-rails, conditional on
+# `global.sidekiq.queues.streaming`). Runs
+# `bundle exec sidekiq -C config/sidekiq/sidekiq_streaming.yml`, which consumes
+# the hard-coded `streaming` queue. `DeliverEventJob` writes each event to the
+# transport named by the organization's `streaming_destinations` row, so this
+# pod assumes an external IAM role. Give its ServiceAccount that permission
+# through EKS Pod Identity.
+# @default -- See child values
+# @section -- Streaming Worker
+streaming-worker:
+  # -- Override the streaming-worker subchart release name
+  # @section -- Streaming Worker
+  nameOverride: lago-streaming-worker
+  config:
+    # -- Disable nested config (uses parent config subchart)
+    # @section -- Streaming Worker
+    enabled: false
+    # -- Config subchart name override
+    # @section -- Streaming Worker
+    nameOverride: lago-config
+  # -- Liveness probe (disabled for workers)
+  # @section -- Streaming Worker
+  livenessProbe:
+    enabled: false
+  # -- Readiness probe (disabled for workers)
+  # @section -- Streaming Worker
+  readinessProbe:
+    enabled: false
+  service:
+    # -- Disable service (no inbound traffic)
+    # @section -- Streaming Worker
+    enabled: false
+  container:
+    # -- Streaming worker entrypoint command — invokes sidekiq with the
+    # `sidekiq_streaming.yml` config that hard-codes the `streaming` queue.
+    # @section -- Streaming Worker
+    command: ["./scripts/start.streaming.worker.sh"]
+    # -- Container ports (none needed)
+    # @section -- Streaming Worker
     ports: []
 
 # -- Clock worker subchart overrides (lago-rails, conditional on `global.sidekiq.queues.clock`)


### PR DESCRIPTION
## Context

The streaming events feature needs a Sidekiq worker with an AWS identity of
its own. The lago-api side is getlago/lago-api#6298, which adds
`config/sidekiq/sidekiq_streaming.yml` and
`scripts/start.streaming.worker.sh`, and states that the worker deployment is
infrastructure work. Tracked as INF-415.

## Description

Adds the `lago-rails` alias `streaming-worker`, gated on
`global.sidekiq.queues.streaming` and off by default. It runs
`./scripts/start.streaming.worker.sh`, which consumes the hard-coded
`streaming` queue.

The alias renders no enqueue-side env var, unlike `alerts`, `wallets`, and
`aiAgent`. `DeliverEventJob` is pinned to the queue with
`queue_as :streaming`, and nothing is enqueued unless the organization holds a
`streaming_destinations` row. So a cluster that leaves the toggle off never
fills the queue, and no rails pod needs a `SIDEKIQ_STREAMING` flag.

The worker writes to a customer transport through `sts:AssumeRole`, so its pod
needs an identity the other workers do not have. The lago-rails
`serviceAccount.create` and `serviceAccount.name` values cover that: a cluster
can bind the pods to one fixed account. EKS Pod Identity maps one account to
one role with no wildcard, and preview releases name their accounts per
branch, so the fixed account is what keeps that to a single association.

## Verification

`helm unittest charts/lago` — 65 pass in 8 suites, 4 cases new:

- the Deployment renders with the start script,
- the worker gets its own ServiceAccount,
- `serviceAccount.create: false` plus a name binds the pods to that account,
- and then the chart renders no ServiceAccount of its own.

`helm template` with the toggle off renders no `lago-streaming-worker` object.
With it on it renders `rel-lago-streaming-worker` as a Deployment and a
ServiceAccount, with `command: ["./scripts/start.streaming.worker.sh"]`.

## Notes for review

- No version bump here. `chart-release.yml` bumps every chart and commits it,
  so the release is a `workflow_dispatch` on `lago-v2` after this merges.
- `charts/lago/README.md` is not regenerated. `helm-docs` gives 91 lines of
  diff because the checked-in file is stale since `0.6.0`, and neither the
  ai-agent-worker commit nor the architecture split touched it.
- `Chart.lock` moved because `helm dependency update` is needed to run the unit
  tests.
